### PR TITLE
feat: add discord like dark theme

### DIFF
--- a/packages/logseq-dicord-like-dark-theme/manifest.json
+++ b/packages/logseq-dicord-like-dark-theme/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "Discord Like Dark Theme",
+  "description": "Discord Like Dark Theme",
+  "author": "dale502",
+  "repo": "dale502/logseq-discord-like-dark-theme",
+  "theme": true
+}


### PR DESCRIPTION
Theme Github repo URL:
https://github.com/dale502/logseq-discord-like-dark-theme