### PR TITLE
Adding logseq-trackhabits2-plugin

### DIFF
--- a/packages/logseq-trackhabits2-plugin/icon.svg
+++ b/packages/logseq-trackhabits2-plugin/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-run" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="13" cy="4" r="1" />
+  <path d="M4 17l5 1l.75 -1.5" />
+  <path d="M15 21l0 -4l-4 -3l1 -6" />
+  <path d="M7 12l0 -3l5 -1l3 3l3 1" />
+</svg>
+
+

--- a/packages/logseq-trackhabits2-plugin/manifest.json
+++ b/packages/logseq-trackhabits2-plugin/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "logseq-trackhabits2-plugin",
+  "description": "Easily track your habits by just tagging your TODO list with #habit-tracker !",
+  "author": "hkgnp",
+  "repo": "hkgnp/logseq-trackhabits2-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-trackhabits2-plugin

## Github releases checklist

- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) action for Github releases. (Optional for theme plugin only)
- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a clear README file.
- [x] a license in the LICENSE file.
