### PR TITLE
adding logseq-swapblocks-plugin

### DIFF
--- a/packages/logseq-swapblocks-plugin/icon.svg
+++ b/packages/logseq-swapblocks-plugin/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-exchange" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="gray" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="5" cy="18" r="2" />
+  <circle cx="19" cy="6" r="2" />
+  <path d="M19 8v5a5 5 0 0 1 -5 5h-3l3 -3m0 6l-3 -3" />
+  <path d="M5 16v-5a5 5 0 0 1 5 -5h3l-3 -3m0 6l3 -3" />
+</svg>
+
+

--- a/packages/logseq-swapblocks-plugin/manifest.json
+++ b/packages/logseq-swapblocks-plugin/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "logseq-swapblocks-plugin",
+  "description": "Simple plugin to swap a reference block with its original block and preserve it's other references.",
+  "author": "hkgnp",
+  "repo": "hkgnp/logseq-swapblocks-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-swapblocks-plugin

## Github releases checklist

- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) action for Github releases. (Optional for theme plugin only)
- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a clear README file.
- [x] a license in the LICENSE file.
