### PR TITLE
adding logseq-quicktodo-plugin

### DIFF
--- a/packages/logseq-quicktodo-plugin/icon.svg
+++ b/packages/logseq-quicktodo-plugin/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-arrow-big-up-lines" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M9 12h-3.586a1 1 0 0 1 -.707 -1.707l6.586 -6.586a1 1 0 0 1 1.414 0l6.586 6.586a1 1 0 0 1 -.707 1.707h-3.586v3h-6v-3z" />
+  <path d="M9 21h6" />
+  <path d="M9 18h6" />
+</svg>
+
+

--- a/packages/logseq-quicktodo-plugin/manifest.json
+++ b/packages/logseq-quicktodo-plugin/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "logseq-tweet-plugin",
+  "description": "This simple plugin helps you to insert a TODO item on your today's journal page, without navigating to it.",
+  "author": "hkgnp",
+  "repo": "hkgnp/logseq-quicktodo-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-quicktodo-plugin

## Github releases checklist

- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) action for Github releases. (Optional for theme plugin only)
- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a clear README file.
- [x] a license in the LICENSE file.
