### PR TITLE
Add task to validate plugins in plugins.json

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -52,12 +52,38 @@
    (let [stats-map (-> "stats.json"
                        slurp
                        (json/parse-string keyword))
+         plugin->author (into {} (map (juxt :id :author) (plugins)))
          stats (->> stats-map
                     (map (fn [[k v]]
                            {:plugin k
+                            :author (plugin->author (name k))
                             :releases (count (:releases v))
                             :downloads (apply + (map (fn [v] (nth v 2)) (:releases v)))
                             :stargazers (:stargazers_count v)}))
                     (sort-by :downloads >))]
      (print-table stats)
-     (println "Total Downloads:" (apply + (map :downloads stats))))}}}
+     (println "Total Downloads:" (apply + (map :downloads stats))))}
+
+  validate-plugins
+  {:doc "Validate plugins.json"
+   :extra-deps {org.babashka/spec.alpha
+                {:git/url "https://github.com/babashka/spec.alpha"
+                 :sha "1a841c4cc1d4f6dab7505a98ed2d532dd9d56b78"}}
+   :requires ([clojure.spec.alpha :as s])
+   :task
+   (let [plugins' (plugins)]
+     ;; Define specs for valid plugins
+     (s/def :bb/title string?)
+     (s/def :bb/description string?)
+     (s/def :bb/author string?)
+     (s/def :bb/repo string?)
+     (s/def :bb/plugin (s/keys :req-un [:bb/title :bb/description
+                                        :bb/author :bb/repo]))
+     (s/def :bb/plugins (s/coll-of :bb/plugin))
+
+     (if-let [errors (s/explain-data :bb/plugins plugins')]
+       (do
+         (pprint/pprint {:errors (:clojure.spec.alpha/problems errors)
+                         :message "Invalid plugins found"})
+         (System/exit 1))
+       (println "All plugins are valid!")))}}}


### PR DESCRIPTION
Hi @xyhp915 . I was trying to install https://github.com/hkgnp/logseq-swapblocks-plugin and I noticed it doesn't show up when searching by name in logseq. I looked at the search and found it's because the [search expects :title](https://github.com/logseq/logseq/blob/f7fad0f3bc8bac82cca2ed75b0add05e23258a50/src/main/frontend/components/plugins.cljs#L472). So I wrote a task to validate plugins in plugins.json and found the following 9 plugins are missing a :title field:

```sh
$ bb validate-plugins | bb '(->> *input* :errors (map (comp :id :val)))'
("logseq-chartrender-plugin" "logseq-datenlp-plugin" "logseq-keywordfrequency-plugin" "logseq-localassets-plugin" "logseq-mergepages-plugin" "logseq-osmmaps-plugin" "logseq-swapblocks-plugin" "logseq-tablerender-plugin" "logseq-toc-plugin")
```

Once these 9 plugins are fixed I think we should add this task as a CI job in order to guarantee the shape of this data in logseq