### PR TITLE
change author

### DIFF
--- a/packages/logseq-wide-eyed/manifest.json
+++ b/packages/logseq-wide-eyed/manifest.json
@@ -1,5 +1,5 @@
 {
-  "title": "Logseq Wide Eyed Plugin",
+  "title": "Wide Eyed",
   "description": "Toggles the visibility of completed/canceled to-dos.",
   "author": "mlanza",
   "repo": "mlanza/logseq-wide-eyed",

--- a/packages/logseq-wide-eyed/manifest.json
+++ b/packages/logseq-wide-eyed/manifest.json
@@ -1,7 +1,7 @@
 {
   "title": "Logseq Wide Eyed Plugin",
   "description": "Toggles the visibility of completed/canceled to-dos.",
-  "author": "Mario T. Lanza",
+  "author": "mlanza",
   "repo": "mlanza/logseq-wide-eyed",
   "icon": "./wide-eyed.svg"
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Modify author to overcome installation issue.  I was unable to install the plugin from the marketplace although I can install it just fine using the "Load unpacked plugin" procedure.  In looking at other plugin manifests, I assume the author being my full name (rather than user name) was the issue.

I keep getting an "[Install Error]:release-asset-not-found" when attempting an install.  Hopefully my fixing the author inconsistency will solve the issue.

Same as mentioned here:
https://github.com/logseq/logseq/issues/3365
