### PR TITLE
adding logseq-sliders-plugin

### DIFF
--- a/packages/logseq-sliders-plugin/icon.svg
+++ b/packages/logseq-sliders-plugin/icon.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-adjustments-horizontal" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <circle cx="14" cy="6" r="2" />
+  <line x1="4" y1="6" x2="12" y2="6" />
+  <line x1="16" y1="6" x2="20" y2="6" />
+  <circle cx="8" cy="12" r="2" />
+  <line x1="4" y1="12" x2="6" y2="12" />
+  <line x1="10" y1="12" x2="20" y2="12" />
+  <circle cx="17" cy="18" r="2" />
+  <line x1="4" y1="18" x2="15" y2="18" />
+  <line x1="19" y1="18" x2="20" y2="18" />
+</svg>
+
+

--- a/packages/logseq-sliders-plugin/manifest.json
+++ b/packages/logseq-sliders-plugin/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "logseq-sliders-plugin",
+  "name": "logseq-sliders-plugin",
+  "description": "Simple plugin to insert a slider into your notes to use as a visualisation tool!",
+  "author": "hkgnp",
+  "repo": "hkgnp/logseq-sliders-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-sliders-plugin

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) action for Github releases. (Optional for theme plugin only)
- [x] a release which includes a release zip pkg from a successful build
- [x] a clear README file, ideally with an image or gif.
- [x] a license in the LICENSE file.
