### PR TITLE
change agenda plugin effect to true

### DIFF
--- a/packages/logseq-agenda/manifest.json
+++ b/packages/logseq-agenda/manifest.json
@@ -3,5 +3,6 @@
   "description": "An agenda manager plugin for logseq" ,
   "author": "haydenull",
   "repo":"haydenull/logseq-plugin-agenda",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
Agenda is run using lsp protocol. This results in a request For a Google Calendar URL CORS error.
Setting effect to true looks like can solve this problem.
