### PR TITLE
adding logseq-recipeimporter-plugin

### DIFF
--- a/packages/logseq-recipeimporter-plugin/icon.svg
+++ b/packages/logseq-recipeimporter-plugin/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-tools-kitchen-2" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="gray" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M19 3v12h-5c-.023 -3.681 .184 -7.406 5 -12zm0 12v6h-1v-3m-10 -14v17m-3 -17v3a3 3 0 1 0 6 0v-3" />
+</svg>
+
+

--- a/packages/logseq-recipeimporter-plugin/manifest.json
+++ b/packages/logseq-recipeimporter-plugin/manifest.json
@@ -1,0 +1,8 @@
+{
+    "title": "logseq-recipeimporter-plugin",
+    "name": "logseq-recipeimporter-plugin",
+    "description": "A simple plugin to import recipes directly into Logseq just by using the URL of the recipe!",
+    "author": "hkgnp",
+    "repo": "hkgnp/logseq-recipeimporter-plugin",
+    "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-recipeimporter-plugin

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) action for Github releases. (Optional for theme plugin only)
- [x] a release which includes a release zip pkg from a successful build
- [x] a clear README file, ideally with an image or gif.
- [x] a license in the LICENSE file.
