### PR TITLE
move block apply effect true

### DIFF
--- a/packages/logseq-move-block/manifest.json
+++ b/packages/logseq-move-block/manifest.json
@@ -4,5 +4,6 @@
   "author": "vipzhicheng",
   "repo": "vipzhicheng/logseq-plugin-move-block",
   "icon": "./icon.png",
-  "sponsors": ["https://www.buymeacoffee.com/vipzhicheng"]
+  "sponsors": ["https://www.buymeacoffee.com/vipzhicheng"],
+  "effect": true
 }

--- a/plugins.json
+++ b/plugins.json
@@ -554,6 +554,7 @@
       "sponsors": [
         "https://www.buymeacoffee.com/vipzhicheng"
       ],
+      "effect": true,
       "id": "logseq-move-block"
     },
     {


### PR DESCRIPTION
# Apply effect true

Plugin Github repo URL: https://github.com/vipzhicheng/logseq-plugin-move-block

move-block plugin installed from Marketplace is always stuck and not popup, but if I load plugin manually, it works perfectly. So I guess the issue may be related to lsp protocol, I want to try if loading the plugin using file protocol the issue would be disappeared.