### PR TITLE
Added `effect: true` for logseq-copy-code-plugin

### DIFF
--- a/packages/logseq-copy-code-plugin/manifest.json
+++ b/packages/logseq-copy-code-plugin/manifest.json
@@ -3,5 +3,6 @@
   "description": "Copy code from code blocks to your clipboard",
   "repo": "vyleung/logseq-copy-code-plugin",
   "author": "vyleung",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
Plugin works when loaded manually, but displays a cross-origin error when installed via the marketplace
![logseq-copy-code-plugin-error-message](https://user-images.githubusercontent.com/64292157/168324428-3fd6f444-8c67-478f-8598-084460a7a118.png)
