### PR TITLE
Dark mode added (logseq-solarized-extended-theme)

### DIFF
--- a/packages/logseq-solarized-extended-theme/manifest.json
+++ b/packages/logseq-solarized-extended-theme/manifest.json
@@ -1,11 +1,11 @@
 {
   "title": "Solarized Extended theme",
-  "description": "Light sepia-solarized Logseq theme with extra stuff",
+  "description": "Solarized Logseq theme with extra stuff",
   "author": "yoyurec",
   "repo": "yoyurec/logseq-solarized-extended-theme",
   "icon": "icon.png",
   "sponsors": [
-    "https://ko-fi.com/yoyurec"
+    "https://www.buymeacoffee.com/yoyurec"
   ],
   "effect": true,
   "theme": true


### PR DESCRIPTION
# Submit update to existing plugin

Plugin Github repo URL:
https://github.com/yoyurec/logseq-solarized-extended-theme

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
