### PR TITLE
Added `effect: true` for logseq-quick-add-plugin

### DIFF
--- a/packages/logseq-quick-add-plugin/manifest.json
+++ b/packages/logseq-quick-add-plugin/manifest.json
@@ -3,5 +3,6 @@
   "description": "Add and duplicate blocks using keyboard shortcuts",
   "repo": "vyleung/logseq-quick-add-plugin",
   "author": "vyleung",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
Plugin works when loaded manually, but displays a cross-origin error when installed via the marketplace
![logseq-copy-code-plugin-error-message](https://user-images.githubusercontent.com/64292157/170669612-e5f4025a-ecd6-4401-aeb6-431ac391ca2d.png)