### PR TITLE
fix(logseq-simpread): set `effect: true`

### DIFF
--- a/packages/logseq-simpread/manifest.json
+++ b/packages/logseq-simpread/manifest.json
@@ -4,6 +4,7 @@
     "author": "OverflowCat",
     "repo": "OverflowCat/logseq-simpread",
     "icon": "./logo.svg",
+    "effect": true,
     "sponsors": [
         "https://www.buymeacoffee.com/overflowcat"
     ]


### PR DESCRIPTION
It looks like I've run into the same problem of https://github.com/logseq/marketplace/pull/181#issuecomment-1128848626 and https://github.com/logseq/marketplace/pull/222/. However, the  `effect: true` is nowhere to be seen in the documentation, and this problem cannot be found when the plugin is loaded manually. Maybe the README needs an update.