### PR TITLE
add effect to vim shortcuts

### DIFF
--- a/packages/logseq-vim-shortcuts/manifest.json
+++ b/packages/logseq-vim-shortcuts/manifest.json
@@ -4,5 +4,6 @@
   "author": "vipzhicheng",
   "repo": "vipzhicheng/logseq-plugin-vim-shortcuts",
   "icon": "icon.png",
-  "sponsors": ["https://www.buymeacoffee.com/vipzhicheng"]
+  "sponsors": ["https://www.buymeacoffee.com/vipzhicheng"],
+  "effect": true
 }


### PR DESCRIPTION
After tested, I found vim shortcuts search highlight feature needs `effect: true` now because it uses `top.document`