### PR TITLE
Wide Eyed plugin requires effect

### DIFF
--- a/packages/logseq-wide-eyed/manifest.json
+++ b/packages/logseq-wide-eyed/manifest.json
@@ -3,5 +3,6 @@
   "description": "Toggles the visibility of completed/canceled to-dos.",
   "author": "Mario T. Lanza",
   "repo": "mlanza/logseq-wide-eyed",
-  "icon": "./wide-eyed.svg"
+  "icon": "./wide-eyed.svg",
+  "effect": true
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL:
https://github.com/mlanza/logseq-wide-eyed

This is a minor manifest update, to use "effect", not a new plugin.  I've retired the original design of Wide Eyed and replaced it with the internals of Style Carousel (which requires effect).

## Github releases checklist

- [X] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [X] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [X] a release which includes a release zip pkg from a successful build.
- [X] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [X] a license in the LICENSE file.
