### PR TITLE
Fix CORS issue for Jira API call in production

### DIFF
--- a/packages/logseq-jira/manifest.json
+++ b/packages/logseq-jira/manifest.json
@@ -4,5 +4,6 @@
   "author": "adyscorpius",
   "repo":"adyscorpius/logseq-jira",
   "icon": "./icon.png",
-  "theme": false
+  "theme": false,
+  "effect": true
 }


### PR DESCRIPTION
As a production plugin on the marketplace bugs out with a CORS issue, seems like setting effect: true should fix it. Wasn't facing the issue in development.


# Submit a new Plugin to Marketplace

Plugin Github repo URL:

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [x] a release which includes a release zip pkg from a successful build.
- [ ] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
