### PR TITLE
added logseq-powertags-plugin

### DIFF
--- a/packages/logseq-powertags-plugin/icon.svg
+++ b/packages/logseq-powertags-plugin/icon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-hash" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="gray" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <line x1="5" y1="9" x2="19" y2="9" />
+  <line x1="5" y1="15" x2="19" y2="15" />
+  <line x1="11" y1="4" x2="7" y2="20" />
+  <line x1="17" y1="4" x2="13" y2="20" />
+</svg>
+
+

--- a/packages/logseq-powertags-plugin/manifest.json
+++ b/packages/logseq-powertags-plugin/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "logseq-powertags-plugin",
+  "name": "logseq-powertags-plugin",
+  "description": "Designate selected tags as power tags, and see them auto-create properties are you use them!a",
+  "author": "hkgnp",
+  "repo": "hkgnp/logseq-powertags-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
@xyhp915 appreciate your help that this plugin needs to be whitelisted as it interacts with the DOM directly through a mutation observer.

# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/logseq-powertags-plugin

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
