### PR TITLE
change batch-op to have effect

### DIFF
--- a/packages/logseq-batch-op/manifest.json
+++ b/packages/logseq-batch-op/manifest.json
@@ -3,5 +3,6 @@
   "description": "Perform queries on the current graph and batch process on the results.",
   "author": "sethyuan",
   "repo": "sethyuan/logseq-plugin-batch-op",
-  "icon": "./icon.png"
+  "icon": "./icon.png",
+  "effect": true
 }


### PR DESCRIPTION
# Change Plugin Manifest

Plugin Github repo URL:

https://github.com/sethyuan/logseq-plugin-batch-op

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
