### PR TITLE
Plugin needs access to parent frame

### DIFF
--- a/packages/logseq-plugin-jump-to-block/manifest.json
+++ b/packages/logseq-plugin-jump-to-block/manifest.json
@@ -3,5 +3,6 @@
 	"description": "Quickly jump to a block within the current page.",
 	"author": "freder",
 	"repo": "freder/logseq-plugin-jump-to-block",
-	"icon": "icon.png"
+	"icon": "icon.png",
+	"effect": true
 }


### PR DESCRIPTION
https://github.com/freder/logseq-plugin-jump-to-block needs access to the parent frame to be able to use the logseq theme colors.

reference: https://discordapp.com/channels/725182569297215569/853262815727976458/1088937977423601802