### PR TITLE
chore: allow access to current theme

### DIFF
--- a/packages/logseq-my-highlights/manifest.json
+++ b/packages/logseq-my-highlights/manifest.json
@@ -4,6 +4,7 @@
   "author": "Ben Force",
   "repo": "theBenForce/logseq-plugin-my-highlights",
   "icon": "icon.svg",
+  "effect": true,
   "sponsors": [
     "https://www.buymeacoffee.com/theBenForce"
   ]


### PR DESCRIPTION
Set `effect` to true so that the plugin can access the current theme colors.

# Submit a new Plugin to Marketplace

Plugin Github repo URL:

## Github releases checklist

- [ ] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [ ] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [ ] a release which includes a release zip pkg from a successful build.
- [ ] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [ ] a license in the LICENSE file.
