### PR TITLE
adding darwis-mathlive-plugin

### DIFF
--- a/packages/darwis-mathlive-plugin/icon.svg
+++ b/packages/darwis-mathlive-plugin/icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-math" width="24" height="24" viewBox="0 0 24 24" stroke-width="2" stroke="gray" fill="none" stroke-linecap="round" stroke-linejoin="round">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none"/>
+  <path d="M16 13l4 4m0 -4l-4 4" />
+  <path d="M20 5h-7l-4 14l-3 -6h-2" />
+</svg>
+
+

--- a/packages/darwis-mathlive-plugin/manifest.json
+++ b/packages/darwis-mathlive-plugin/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "darwis-mathlive-plugin",
+  "name": "darwis-mathlive-plugin",
+  "description": "Use Mathlive to input mathematical expressions in Logseq.",
+  "author": "hkgnp",
+  "repo": "hkgnp/darwis-mathlive-plugin",
+  "icon": "./icon.svg"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

Plugin Github repo URL: https://github.com/hkgnp/darwis-mathlive-plugin

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (Optional for theme plugin only).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
