### PR TITLE
fix: nord-theme remove version string

### DIFF
--- a/packages/nord-theme/manifest.json
+++ b/packages/nord-theme/manifest.json
@@ -2,7 +2,6 @@
     "title": "Nord theme",
     "description": "An arctic, north-bluish color palette 🧊",
     "author": "Bad3r",
-    "version": "0.0.1",
     "repo": "Bad3r/Logseq-Nord-Theme",
     "icon": "icon.svg",
     "theme": true


### PR DESCRIPTION
I included the version number in the manifest by mistake. This causes Nord theme always to show that there is an update since this version mismatches the one from package.json 

- close https://github.com/Bad3r/Logseq-Nord-Theme/issues/8