### PR TITLE
chore: add sponsors block to logseq-chess

### DIFF
--- a/packages/logseq-chess/manifest.json
+++ b/packages/logseq-chess/manifest.json
@@ -4,5 +4,8 @@
   "author": "r8",
   "repo": "r8/logseq-chess",
   "icon": "icon.png",
+  "sponsors": [
+    "https://www.buymeacoffee.com/reight"
+  ],
   "effect": true
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  https://github.com/r8/logseq-chess

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
