### PR TITLE
Set logseq graph analisys effect true

### DIFF
--- a/packages/logseq-graph-analysis/manifest.json
+++ b/packages/logseq-graph-analysis/manifest.json
@@ -5,5 +5,6 @@
   "author": "Stephen Solka",
   "repo": "trashhalo/logseq-graph-analysis",
   "icon": "icon.png",
-  "sponsors": ["https://ko-fi.com/trashhalo"]
+  "sponsors": ["https://ko-fi.com/trashhalo"],
+  "effect": true
 }


### PR DESCRIPTION
# Update logseq-graph-analysis manifest -  effect: true

**Plugin Github repo URL**: https://github.com/trashhalo/logseq-graph-analysis

I'm currently maintaining this plugin. This change needed to access the current theme and support it in a plugin. It will provide more seamless UI for users. 

Here is an example of implementation. Probably in a future it will access more properties - font, accent colors, etc

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
