### PR TITLE
Update description and `effect: true` for `logseq13-missing-commands` plugin

### DIFF
--- a/packages/logseq13-missing-commands/manifest.json
+++ b/packages/logseq13-missing-commands/manifest.json
@@ -1,6 +1,6 @@
 {
   "title": "Missing Commands & Views",
-  "description": "🪚 Sorting blocks, tabular view, auto complete in search, split by sentences, remove numbering, etc." ,
+  "description": "Sort blocks, TAB-trigger on search, split by sentences, parse text structure, blocks navigation, etc." ,
   "author": "stdword",
   "repo": "stdword/logseq13-missing-commands",
   "icon": "icon.png",

--- a/packages/logseq13-missing-commands/manifest.json
+++ b/packages/logseq13-missing-commands/manifest.json
@@ -6,5 +6,6 @@
   "icon": "icon.png",
   "sponsors": [
     "https://www.buymeacoffee.com/stdword"
-  ]
+  ],
+  "effect": true
 }


### PR DESCRIPTION
# Update the plugin on Marketplace

**Plugin Github repo URL:**  https://github.com/stdword/logseq13-missing-commands

1. Updated description
2. Added `effect: true` to access handling keys while editing blocks and searching to support [these](https://github.com/stdword/logseq13-missing-commands?tab=readme-ov-file#1-features) features.

