### PR TITLE
add Logseq Gallery plugins

### DIFF
--- a/packages/logseq-gallery/manifest.json
+++ b/packages/logseq-gallery/manifest.json
@@ -1,0 +1,10 @@
+{
+    "title": "Logseq Gallery",
+    "description": "A plugin for Gallery support in logseq",
+    "author": "CorrectRoadH",
+    "repo": "CorrectRoadH/logseq-gallery",
+    "sponsors": [
+      "https://github.com/sponsors/CorrectRoadH"
+    ],
+    "icon": "icon.png"
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  https://github.com/CorrectRoadH/logseq-gallery

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

# Usage
`{{renderer :gallery, (page-property restaurant <% current page %>), 萨利亚}}`

# Sceenshots
![CleanShot 2024-02-04 at 23 37 54@2x](https://github.com/logseq/marketplace/assets/29306285/b0609024-294c-429a-b359-aa490b9dbd29)


