### PR TITLE
fix Ensure effect value is true in logseq-plugin-for-misskey

### DIFF
--- a/packages/logseq-plugin-for-misskey/manifest.json
+++ b/packages/logseq-plugin-for-misskey/manifest.json
@@ -3,5 +3,6 @@
     "description": "LogseqからMisskeyにノートを投稿したりLogseqにMisskeyのノートを埋め込めるようになります",
     "author": "minimarimo3",
     "repo": "minimarimo3/logseq-plugin-for-misskey",
-    "icon": "icon_ki.png"
+    "icon": "icon_ki.png",
+    "effect": true
 }


### PR DESCRIPTION
There is a decentralized microblogging SNS called [Misskey](https://github.com/misskey-dev/misskey). This extension provides the ability to [post text and media to Misskey from Logseq](https://github.com/minimarimo3/logseq-plugin-for-misskey/blob/main/main.js#L298) and to [embed Misskey posts into Logseq](https://github.com/minimarimo3/logseq-plugin-for-misskey/blob/main/main.js#L478). The [media posting feature uses URLs with the `file://` scheme](https://github.com/minimarimo3/logseq-plugin-for-misskey/blob/main/main.js#L228), so it does not work when loaded with the `lsp://` scheme. This is a fix for that issue. 
This plugin has been submitted in a pull request: (Add logseq-plugin-for-misskey #514).
