### PR TITLE
Set logseq-koreader-sync effect to `true`.

### DIFF
--- a/packages/logseq-koreader-sync/manifest.json
+++ b/packages/logseq-koreader-sync/manifest.json
@@ -3,5 +3,6 @@
   "description": "A koreader to logseq syncing plugin. Reference and read annotations in your notebook.",
   "repo": "isosphere/logseq-koreader-sync",
   "author": "isosphere",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
Setting `effect` to `true` is required for `showDirectoryPicker`; this plugin reads document annotations from koreader on the filesystem. As discussed on [discord](https://discord.com/channels/725182569297215569/1206424524149628951).

# Update an Existing Plugin

**Plugin Github repo URL:**  https://github.com/isosphere/logseq-koreader-sync

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
