### PR TITLE
Update sponsor link for anki sync plugin

### DIFF
--- a/packages/logseq-anki-sync/manifest.json
+++ b/packages/logseq-anki-sync/manifest.json
@@ -6,6 +6,7 @@
   "icon": "./icon.png",
   "effect": true,
   "sponsors": [
+    "https://github.com/sponsors/debanjandhar12",
     "https://www.buymeacoffee.com/debanjandhar12"
   ]
 }


### PR DESCRIPTION
# Update sponsor link for anki sync plugin

**Plugin Github repo URL**: https://github.com/debanjandhar12/logseq-anki-sync

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
