### PR TITLE
Add effect true for url title tagger

### DIFF
--- a/packages/logseq-url-title-tagger/manifest.json
+++ b/packages/logseq-url-title-tagger/manifest.json
@@ -3,5 +3,6 @@
   "description": "Add title to URL in markdown automatically",
   "author": "imjn",
   "repo":"imjn/logseq-url-title-tagger",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  https://github.com/imjn/logseq-url-title-tagger

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

I see there's an error which says `Uncaught (in promise) DOMException: Blocked a frame with origin "lsp://logseq.io" from accessing a cross-origin frame.` and realized that I forgot to add the effect option.