### PR TITLE
update catppuccin theme entry

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -520,6 +520,7 @@
         "https://opencollective.com/catppuccin"
       ],
       "theme": true,
+      "effect": true,
       "id": "logseq-catppuccin",
       "addedAt": 1675028902000
     },


### PR DESCRIPTION
# Update Plugin to Marketplace

This is to load plugin using `file://` proto instead of `lsp://` so that it can access the parent and avoid cross-origin frame restriction. I require this to add an additional className for a [new setting](https://github.com/catppuccin/logseq/pull/30).

**Plugin Github repo URL:** [https://github.com/catppuccin/logseq](https://github.com/catppuccin/logseq)

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
