### PR TITLE
Two plugins where the icon values in the manifest are not accurate

### DIFF
--- a/packages/logseq-urls-md/manifest.json
+++ b/packages/logseq-urls-md/manifest.json
@@ -3,5 +3,5 @@
     "description": "A Plugin that help you to Convert URL to Markdown links when you paste a url in logseq." ,
     "author": "superman66",
     "repo":"superman66/logseq-plugin-url-md",
-    "icon": "icon.png"
+    "icon": "icon.jpeg"
   }

--- a/packages/logseq-wiki-search/manifest.json
+++ b/packages/logseq-wiki-search/manifest.json
@@ -3,5 +3,5 @@
     "description": "Search Wikipedia and add the content as a block or a page" ,
     "author": "enchantmenttable",
     "repo":"enchantmenttable/logseq-wiki-search",
-    "icon": "icon.png"
+    "icon": "logo.png"
 }


### PR DESCRIPTION
1.  "repo":"enchantmenttable/logseq-wiki-search",
     ~~"icon": "icon.png"~~
     → "icon": "logo.png"
2.  "repo":"superman66/logseq-plugin-url-md",
    ~~"icon": "icon.png"~~
    → "icon": "icon.jpeg"

