### PR TITLE
update: Added effect to logseq-furigana

### DIFF
--- a/packages/logseq-furigana/manifest.json
+++ b/packages/logseq-furigana/manifest.json
@@ -7,5 +7,6 @@
     "https://github.com/sponsors/daviddavo",
     "https://www.buymeacoffee.com/ddavo"
   ],
-  "icon": "icon.svg"
+  "icon": "icon.svg",
+  "effect": true
 }


### PR DESCRIPTION
This is not a new plugin, this is a heavy refactoring of the [logseq-furigana](https://github.com/daviddavo/logseq-furigana) plugin, which now uses a MutationObserver to replace every instance of `漢字[かんじ]` with ruby tags: `<ruby>漢字<rt>かんじ</ruby>`: <ruby>漢字<rt>かんじ</ruby>

It doesn't work with lsp, it needs the file protocol or it raises a cross-origin frame error