### PR TITLE
logseq-toc-plugin: add page level toc

### DIFF
--- a/packages/logseq-toc-plugin/manifest.json
+++ b/packages/logseq-toc-plugin/manifest.json
@@ -2,7 +2,8 @@
   "title": "logseq-toc-plugin",
   "name": "logseq-toc-plugin",
   "description": "Interactive (style-able), real-time rendering of Table of Contents.",
-  "author": "hkgnp",
-  "repo": "hkgnp/logseq-toc-plugin",
-  "icon": "./icon.svg"
+  "author": "benjypng",
+  "repo": "benjypng/logseq-toc-plugin",
+  "icon": "./icon.svg",
+  "effect": "true"
 }


### PR DESCRIPTION
# New Feature

Added page-level TOC, which requires access to DOM. 

![](https://github.com/benjypng/logseq-toc-plugin/blob/main/screenshots/pagetoc.gif?raw=true)

# Submit a new Plugin to Marketplace

**Plugin Github repo URL:** https://github.com/benjypng/logseq-toc-plugin

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
