### PR TITLE
make effect true to allow access to assets

### DIFF
--- a/packages/logseq-ask-pdf/manifest.json
+++ b/packages/logseq-ask-pdf/manifest.json
@@ -6,5 +6,5 @@
     "icon": "icon.png",
     "theme": false,
     "sponsors": [],
-    "effect": false
+    "effect": true
   }


### PR DESCRIPTION
# Make effect option true for logseq-ask-pdf

## Reason
I spent a lot of time trying to find a way to access pdf, edn files in the assets folder, and finally realised that the `effect` option needs to be turned on.

logseq-ask-pdf is a plugin that reads a local pdf file and utilises LLM to ask questions about the contents of the pdf.

Is it ok for me to turn on the effect option?

---

**Plugin Github repo URL:**  https://github.com/hi-jin/logseq-ask-pdf
## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
