### PR TITLE
add logseq-richtexteditor-plugin | remove effect:true from zoteroloca…

### DIFF
--- a/packages/logseq-richtexteditor-plugin/icon.svg
+++ b/packages/logseq-richtexteditor-plugin/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="gray" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="icon icon-tabler icons-tabler-outline icon-tabler-edit">
+  <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+  <path d="M7 7h-1a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-1" />
+  <path d="M20.385 6.585a2.1 2.1 0 0 0 -2.97 -2.97l-8.415 8.385v3h3l8.385 -8.415z" />
+  <path d="M16 5l3 3" />
+</svg>

--- a/packages/logseq-richtexteditor-plugin/manifest.json
+++ b/packages/logseq-richtexteditor-plugin/manifest.json
@@ -1,0 +1,9 @@
+{
+  "title": "logseq-richtexteditor-plugin",
+  "name": "logseq-richtexteditor-plugin",
+  "description": "Inserts a rich text editor into your graph for easier editing. Supports printing too.",
+  "author": "benjypng",
+  "repo": "benjypng/logseq-richtexteditor-plugin",
+  "icon": "./icon.svg",
+  "effect": true
+}

--- a/packages/logseq-zoterolocal-plugin/manifest.json
+++ b/packages/logseq-zoterolocal-plugin/manifest.json
@@ -4,6 +4,5 @@
   "description": "Connect to Zotero locally using Zotero Beta 7 (and above), import and keep track of your Zotero library.",
   "author": "benjypng",
   "repo": "benjypng/logseq-zoterolocal-plugin",
-  "icon": "./icon.svg",
-  "effect": true
+  "icon": "./icon.svg"
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  https://github.com/benjypng/logseq-richtexteditor-plugin
This plugin needs `effect:true`.

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

Also modified the need to have effect: true from the zoterolocal plugin.