### PR TITLE
logseq quick-date update manifest.json to correctly refer to logo.jpg

### DIFF
--- a/packages/logseq-quick-date/manifest.json
+++ b/packages/logseq-quick-date/manifest.json
@@ -3,5 +3,5 @@
   "description": "Support more dates like the in-build 'Tomorrow' command such as 'Last Wednesday' and 'Next Friday'.",
   "author": "Hannes Kuchelmeister",
   "repo": "13hannes11/logseq-quick-date",
-  "icon": "icon.png"
+  "icon": "logo.jpg"
 }


### PR DESCRIPTION
The logo was pointing to the wrong file.