### PR TITLE
Update unmaintained plugin - logseq-plugin-audiobookshelf-import

### DIFF
--- a/packages/logseq-plugin-audiobookshelf-import/manifest.json
+++ b/packages/logseq-plugin-audiobookshelf-import/manifest.json
@@ -1,8 +1,8 @@
 {
     "title": "logseq-plugin-audiobookshelf-import",
     "description": "Import Audiobookshelf items into Logseq.",
-    "author": "Demistify",
-    "repo": "etopeter/logseq-plugin-audiobookshelf-import",
+    "author": "Gandalf-the-Blue & Demistify",
+    "repo": "Gandalf-the-Blue/logseq-plugin-audiobookshelf-import",
     "icon": "icon.png",
     "effect": true
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  [https://github.com/Gandalf-the-Blue/logseq-plugin-audiobookshelf-import/](https://github.com/Gandalf-the-Blue/logseq-plugin-audiobookshelf-import/)

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.


The original maintainer @etopeter is not active any more and there have been breaking changes in the API which cause the plugin to lose functionality, since its last update in January 2023. I have forked the original repo and fixed some bugs, though I'm sure there will be more, which I would also like to fix and maintain the plugin repository.
 