### PR TITLE
minor: disambiguate between 2 copilot plugins

### DIFF
--- a/packages/logseq-plugin-copilot/manifest.json
+++ b/packages/logseq-plugin-copilot/manifest.json
@@ -1,5 +1,5 @@
 {
-    "title": "Logseq Copilot",
+    "title": "Copilot",
     "description": "Talk to AI about your Logseq notes.",
     "author": "Abhin Chhabra",
     "repo": "chhabrakadabra/logseq-plugin-copilot",


### PR DESCRIPTION
There are 2 plugins with the name "Logseq Copilot" and as the author of one of them, I wanted to simplify the name of my plugin and hopefully reduce some confusion.

**Plugin Github repo URL:** https://github.com/chhabrakadabra/logseq-plugin-copilot

## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
