### PR TITLE
Transfer ownership of logseq-interstitial-heading-plugin

### DIFF
--- a/packages/logseq-interstitial/manifest.json
+++ b/packages/logseq-interstitial/manifest.json
@@ -1,7 +1,7 @@
 {
   "title": "Logseq Interstitial Journal",
   "description": "Interstitial Journaling plugin: create time stamps, add (random) notes and notes to self to your journal",
-  "repo": "QWxleA/logseq-interstitial-heading-plugin",
+  "repo": "Mikilio/logseq-interstitial-heading-plugin",
   "author": "Alex Qwxlea",
   "icon": "icon.png"
 }


### PR DESCRIPTION
This transfer is due to the original repo being inactive for a long time and not merging PRs. I use the plugin and extended its features for me personally, so I am willing to maintain it.


## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
