### PR TITLE
fix: update icon path in Habitica Tasks plugin manifest

### DIFF
--- a/packages/logseq-habitica-tasks/manifest.json
+++ b/packages/logseq-habitica-tasks/manifest.json
@@ -3,5 +3,5 @@
   "description": "A plugin that integrates Logseq tasks with Habitica",
   "author": "caffbit",
   "repo": "caffbit/logseq-plugin-habitica",
-  "icon": "./logo.svg"
+  "icon": "./icon.svg"
 }


### PR DESCRIPTION
Oops, my bad - had the wrong path in the last update. Should be ./icon.svg, not ./logo.svg!

# Submit a new Plugin to Marketplace

**Plugin Github repo URL:**  [https://github.com/caffbit/logseq-plugin-habitica](https://github.com/caffbit/logseq-plugin-habitica)


## Github releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.
