### PR TITLE
 Fix CORS policy issue - Change effect to true

### DIFF
--- a/catalog/generated/index.html
+++ b/catalog/generated/index.html
@@ -7287,7 +7287,7 @@
     </div>
 
       <div class="footer">
-        Page generated: <span id="footer-date">01-09-2025, 09:27:39 UTC</span> &mdash;
+        Page generated: <span id="footer-date">13-09-2025, 09:52:27 UTC</span> &mdash;
         Plugins listed: <span id="footer-count">468</span>
       </div>
       <script>

--- a/catalog/generated/index.html
+++ b/catalog/generated/index.html
@@ -7287,7 +7287,7 @@
     </div>
 
       <div class="footer">
-        Page generated: <span id="footer-date">13-09-2025, 09:52:27 UTC</span> &mdash;
+        Page generated: <span id="footer-date">13-09-2025, 09:53:53 UTC</span> &mdash;
         Plugins listed: <span id="footer-count">468</span>
       </div>
       <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7287,7 +7287,7 @@
     </div>
 
       <div class="footer">
-        Page generated: <span id="footer-date">01-09-2025, 09:27:39 UTC</span> &mdash;
+        Page generated: <span id="footer-date">13-09-2025, 09:52:27 UTC</span> &mdash;
         Plugins listed: <span id="footer-count">468</span>
       </div>
       <script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -7287,7 +7287,7 @@
     </div>
 
       <div class="footer">
-        Page generated: <span id="footer-date">13-09-2025, 09:52:27 UTC</span> &mdash;
+        Page generated: <span id="footer-date">13-09-2025, 09:53:53 UTC</span> &mdash;
         Plugins listed: <span id="footer-count">468</span>
       </div>
       <script>

--- a/packages/logseq-inbox-telegram-plugin/manifest.json
+++ b/packages/logseq-inbox-telegram-plugin/manifest.json
@@ -1,8 +1,10 @@
 {
   "title": "Inbox Telegram",
-  "description": "A Logseq plugin that reads Telegram chat and pull messages to daily journal." ,
+  "description": "A Logseq plugin that reads Telegram chat and pull messages to daily journal",
   "author": "shady2k",
-  "repo":"shady2k/logseq-inbox-telegram-plugin",
+  "repo": "shady2k/logseq-inbox-telegram-plugin",
   "icon": "./icon.png",
-  "theme": false
+  "theme": false,
+  "web": false,
+  "effect": true
 }


### PR DESCRIPTION
  Summary

  This PR requests changing effect: true in the manifest for the existing Logseq Inbox Telegram plugin to resolve a blocked CORS policy problem that prevents the plugin from
  working when installed from the marketplace.

  Background

  The plugin currently works perfectly in development mode but fails when installed from the Logseq marketplace due to cross-origin restrictions in the sandboxed environment.
   Users encounter the error:

  SecurityError: Failed to read a named property 'logseq' from 'Window': Blocked a frame with origin "lsp://logseq.io" from accessing a cross-origin frame.

  Repository

https://github.com/shady2k/logseq-inbox-telegram-plugin

  Related Issue

  📋 This addresses the cross-frame origin issue discussed in: https://discuss.logseq.com/t/need-help-resolving-a-plugin-issue-regarding-cross-frame-origin/5750/7

  Request

  Please update the manifest to include:
  {
    "effect": true
  }

  This change is necessary because the plugin makes external API calls to the Telegram Bot API (https://api.telegram.org/bot*/getUpdates) to fetch messages, which requires
  cross-origin permissions to function properly in the marketplace environment.