### PR TITLE
Add logseq-preview-mode plugin

### DIFF
--- a/packages/logseq-preview-mode/manifest.json
+++ b/packages/logseq-preview-mode/manifest.json
@@ -2,7 +2,7 @@
   "title": "Preview Mode Toggle",
   "description": "Toggle preview mode for blocks and pages in Logseq, allowing distraction-free reading experience",
   "author": "zippermonkey",
-  "repo": "zippermonkey/logseq-plugin",
+  "repo": "zippermonkey/logseq-preview-mode",
   "icon": "./icon.png",
   "theme": false,
   "sponsors": [],

--- a/packages/logseq-preview-mode/manifest.json
+++ b/packages/logseq-preview-mode/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Preview Mode Toggle",
+  "description": "Toggle preview mode for blocks and pages in Logseq, allowing distraction-free reading experience",
+  "author": "zippermonkey",
+  "repo": "zippermonkey/logseq-plugin",
+  "icon": "./icon.png",
+  "theme": false,
+  "sponsors": [],
+  "web": false,
+  "effect": false
+}


### PR DESCRIPTION
## Plugin Description

A Logseq plugin for toggling preview mode, allowing users to quickly switch between edit and preview modes for a distraction-free reading experience.

### ✨ Features
- **Edit Mode**: Display Logseq blocks in normal markdown source mode (default Logseq behavior)
- **Preview Mode**: Blocks remain in rendered markdown state even when focused, preventing editing
- **Link Navigation**: Support clicking `[[page]]` double-bracket links for page navigation in preview mode
- **Quick Toggle**: One-click mode switching via toolbar button
- **State Memory**: Automatically remember user's mode choice, persisting across restarts
- **Smart Protection**: Prevents accidental editing while allowing normal interactions

### 🛠️ Technical Details
- Lightweight implementation with no external dependencies
- Smart CSS injection for precise editing control
- Intelligent event handling for link navigation
- State persistence using Logseq settings API

### 📋 Checklist
- [x] Plugin follows marketplace guidelines
- [x] manifest.json is properly formatted
- [x] Plugin has been tested with current Logseq version
- [x] Plugin is published with a GitHub release
- [x] Release includes zip file for installation

### 🔗 Links
- Plugin Repository: https://github.com/zippermonkey/logseq-preview-mode
- GitHub Release: https://github.com/zippermonkey/logseq-preview-mode/releases/tag/v0.0.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)