### PR TITLE
Add Built Simple Research plugin

### DIFF
--- a/packages/builtsimple-research/manifest.json
+++ b/packages/builtsimple-research/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Built Simple Research",
+  "description": "Search PubMed, ArXiv, and Wikipedia directly from Logseq.",
+  "author": "Built-Simple.ai <contact@built-simple.ai>",
+  "repo": "Built-Simple/logseq-builtsimple",
+  "icon": "icon.png",
+  "effect": false
+}


### PR DESCRIPTION
Adds Built Simple Research plugin for searching PubMed, ArXiv, and Wikipedia from Logseq.

**Repo:** https://github.com/Built-Simple/logseq-builtsimple
**Release:** https://github.com/Built-Simple/logseq-builtsimple/releases/tag/1.0.0