### PR TITLE
Add Degrande Bullet Threading plugin

### DIFF
--- a/packages/degrande-bullet-threading/icon.svg
+++ b/packages/degrande-bullet-threading/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Degrande Bullet Threading icon">
+  <defs>
+    <linearGradient id="bg" x1="8" y1="8" x2="56" y2="56" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#0f766e"/>
+      <stop offset="1" stop-color="#2563eb"/>
+    </linearGradient>
+    <linearGradient id="thread" x1="0" y1="16" x2="0" y2="52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#f8fafc"/>
+      <stop offset="1" stop-color="#93c5fd"/>
+    </linearGradient>
+  </defs>
+  <rect x="8" y="8" width="48" height="48" rx="14" fill="url(#bg)"/>
+  <!-- bullet dots -->
+  <circle cx="24" cy="20" r="3" fill="#f8fafc"/>
+  <circle cx="32" cy="32" r="3" fill="#f8fafc"/>
+  <circle cx="32" cy="44" r="3" fill="#f8fafc"/>
+  <!-- threading line -->
+  <path d="M24 23 L24 29 Q24 32 27 32 L29 32" fill="none" stroke="url(#thread)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M32 35 L32 41" fill="none" stroke="url(#thread)" stroke-width="2.5" stroke-linecap="round"/>
+</svg>

--- a/packages/degrande-bullet-threading/manifest.json
+++ b/packages/degrande-bullet-threading/manifest.json
@@ -1,0 +1,9 @@
+{
+  "title": "Degrande Bullet Threading",
+  "description": "Colorful active-path bullet threading for Logseq DB graphs with accent colors, rainbow mode, adjustable width, shape, and motion.",
+  "author": "mugpet",
+  "repo": "mugpet/logseq-db-degrande-bullet-threading",
+  "icon": "icon.svg",
+  "effect": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Hi there! 👋

I'd like to submit **Degrande Bullet Threading** to the Logseq marketplace.

It adds colorful active-path bullet threading for **Logseq DB graphs** — drawing a line from the root block down to the selected block so you can see where you are in deep outlines. Features include accent colors, rainbow mode, adjustable thread width, shape ()Square / Rounded), end mode ()Top / Side), and motion animation. All settings are accessible from a visual panel with live preview.

- **Repo**: https://github.com/mugpet/logseq-db-degrande-bullet-threading
- **Release**: https://github.com/mugpet/logseq-db-degrande-bullet-threading/releases/tag/v0.2.9
- **DB-only plugin** ()`supportsDBOnly: true`)
- Uses `effect: true` for SVG overlay threading

The README includes screenshots showing the plugin in action. Thank you for your time reviewing this!