### PR TITLE
fix: add supportsDB flag to degrande-bullet-threading

### DIFF
--- a/packages/degrande-bullet-threading/manifest.json
+++ b/packages/degrande-bullet-threading/manifest.json
@@ -5,5 +5,6 @@
   "repo": "mugpet/logseq-db-degrande-bullet-threading",
   "icon": "icon.svg",
   "effect": true,
+  "supportsDB": true,
   "supportsDBOnly": true
 }


### PR DESCRIPTION
Adds the missing `supportsDB: true` flag to the degrande-bullet-threading manifest so the marketplace UI shows the Logseq DB compatibility badge.