### PR TITLE
fix: add supportsDB flag to degrande-calendar

### DIFF
--- a/packages/degrande-calendar/manifest.json
+++ b/packages/degrande-calendar/manifest.json
@@ -5,5 +5,6 @@
   "repo": "mugpet/logseq-db-degrande-calendar",
   "icon": "icon.svg",
   "effect": true,
+  "supportsDB": true,
   "supportsDBOnly": true
 }


### PR DESCRIPTION
Adds the missing `supportsDB: true` flag to the degrande-calendar manifest so the marketplace UI shows the Logseq DB compatibility badge.