### PR TITLE
Add GitSeq and LinSeq plugins

### DIFF
--- a/packages/gitseq/manifest.json
+++ b/packages/gitseq/manifest.json
@@ -2,7 +2,7 @@
   "title": "GitSeq",
   "description": "Encrypted git sync for Logseq. One keystroke to commit & push.",
   "author": "Maxim Khomiakov",
-  "repo": "pihalf/logseq-plugin-git-sync",
+  "repo": "pihalf/gitseq",
   "icon": "logo.png",
   "theme": false,
   "effect": false

--- a/packages/gitseq/manifest.json
+++ b/packages/gitseq/manifest.json
@@ -1,5 +1,5 @@
 {
-  "title": "gitseq",
+  "title": "GitSeq",
   "description": "Encrypted git sync for Logseq. One keystroke to commit & push.",
   "author": "Maxim Khomiakov",
   "repo": "pihalf/logseq-plugin-git-sync",

--- a/packages/gitseq/manifest.json
+++ b/packages/gitseq/manifest.json
@@ -1,0 +1,9 @@
+{
+  "title": "gitseq",
+  "description": "Encrypted git sync for Logseq. One keystroke to commit & push.",
+  "author": "Maxim Khomiakov",
+  "repo": "pihalf/logseq-plugin-git-sync",
+  "icon": "logo.png",
+  "theme": false,
+  "effect": false
+}

--- a/packages/logseq-plugin-linear/manifest.json
+++ b/packages/logseq-plugin-linear/manifest.json
@@ -1,5 +1,5 @@
 {
-  "title": "Linear",
+  "title": "LinSeq",
   "description": "Linear integration for Logseq — link issues, post comments, track sprints from your journal.",
   "author": "Maxim Khomiakov",
   "repo": "pihalf/logseq-plugin-linear",

--- a/packages/logseq-plugin-linear/manifest.json
+++ b/packages/logseq-plugin-linear/manifest.json
@@ -2,7 +2,7 @@
   "title": "LinSeq",
   "description": "Linear integration for Logseq — link issues, post comments, track sprints from your journal.",
   "author": "Maxim Khomiakov",
-  "repo": "pihalf/logseq-plugin-linear",
+  "repo": "pihalf/linseq",
   "icon": "logo.png",
   "theme": false,
   "effect": false

--- a/packages/logseq-plugin-linear/manifest.json
+++ b/packages/logseq-plugin-linear/manifest.json
@@ -1,0 +1,9 @@
+{
+  "title": "Linear",
+  "description": "Linear integration for Logseq — link issues, post comments, track sprints from your journal.",
+  "author": "Maxim Khomiakov",
+  "repo": "pihalf/logseq-plugin-linear",
+  "icon": "logo.png",
+  "theme": false,
+  "effect": false
+}


### PR DESCRIPTION
## New plugins

### GitSeq
Encrypted git sync for Logseq. One keystroke (Cmd+S) to commit & push, with git-crypt encryption support.

- **Repo**: https://github.com/pihalf/gitseq
- **Release**: https://github.com/pihalf/gitseq/releases/tag/v0.1.0
- **License**: MIT

### LinSeq
Linear integration for Logseq — link issues, post comments, create tickets, and track sprint progress directly from your journal.

- **Repo**: https://github.com/pihalf/linseq
- **Release**: https://github.com/pihalf/linseq/releases/tag/v0.1.0
- **License**: MIT

## Checklist
- [x] Legal manifest.json for each plugin
- [x] GitHub Actions CI workflow generating release artifacts
- [x] Release zip attached to GitHub Release
- [x] Clear README with usage documentation
- [x] MIT License included