### PR TITLE
Add File Explorer plugin

### DIFF
--- a/packages/logseq-file-explorer/icon.svg
+++ b/packages/logseq-file-explorer/icon.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2e3440"/>
+      <stop offset="1" stop-color="#1a1d24"/>
+    </linearGradient>
+    <linearGradient id="folder" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#88c0d0"/>
+      <stop offset="1" stop-color="#5e81ac"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#bg)"/>
+  <path d="M24 42 L24 98 Q24 104 30 104 L98 104 Q104 104 104 98 L104 52 Q104 46 98 46 L58 46 L50 38 L30 38 Q24 38 24 44 Z" fill="url(#folder)" opacity="0.95"/>
+  <rect x="34" y="58" width="44" height="3" rx="1.5" fill="#eceff4" opacity="0.85"/>
+  <rect x="34" y="70" width="60" height="3" rx="1.5" fill="#eceff4" opacity="0.65"/>
+  <rect x="34" y="82" width="36" height="3" rx="1.5" fill="#eceff4" opacity="0.45"/>
+  <circle cx="92" cy="60" r="2" fill="#a3be8c"/>
+  <circle cx="92" cy="72" r="2" fill="#ebcb8b"/>
+  <circle cx="92" cy="84" r="2" fill="#bf616a"/>
+</svg>

--- a/packages/logseq-file-explorer/manifest.json
+++ b/packages/logseq-file-explorer/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "File Explorer",
+  "description": "Obsidian-style file explorer for Logseq's left sidebar — Files & Pages views, right-click menu, drag-and-drop.",
+  "author": "kendreaditya",
+  "repo": "kendreaditya/logseq-file-explorer",
+  "icon": "icon.svg",
+  "theme": false
+}


### PR DESCRIPTION
## Plugin: File Explorer

An Obsidian-style file explorer for Logseq's left sidebar.

- **Repo:** https://github.com/kendreaditya/logseq-file-explorer
- **Release:** https://github.com/kendreaditya/logseq-file-explorer/releases/tag/v0.1.0 (zip attached)
- **Author:** @kendreaditya

## Features

- Two views: **Files** (raw filesystem tree) and **Pages** (namespace-grouped).
- Matches Logseq's native sidebar styling (theme-synced via CSS vars).
- Right-click menu: new file/folder, duplicate, rename, move, delete, copy path (abs/rel), reveal in Finder, open in default app, open to the right / new window, insert link in today's journal.
- Drag-and-drop file moves with drop-target highlighting.
- Journal-aware: files under `journals/` render with the user's preferred date format.
- Canonical-page-safe: rename/delete of `pages/` and `journals/` files uses Logseq's page APIs; other `.md` files use direct filesystem ops (avoids ghost-file bug).

<img width="1245" height="932" alt="image" src="https://github.com/user-attachments/assets/a649100d-4bd3-4635-a7a3-ad399deec0b5" />

## Checklist

- [x] Release has a `logseq-file-explorer.zip` attached (via GitHub Actions).
- [x] README explains what the plugin does and how to use it.
- [x] Screenshot/gif (will add in a follow-up).