### PR TITLE
Add Resurface plugin

### DIFF
--- a/packages/resurface/icon.svg
+++ b/packages/resurface/icon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#2e3440"/>
+      <stop offset="1" stop-color="#1a1d24"/>
+    </linearGradient>
+    <linearGradient id="ripple" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#88c0d0"/>
+      <stop offset="1" stop-color="#5e81ac"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#bg)"/>
+  <circle cx="64" cy="78" r="44" fill="none" stroke="url(#ripple)" stroke-width="2" opacity="0.25"/>
+  <circle cx="64" cy="78" r="32" fill="none" stroke="url(#ripple)" stroke-width="2" opacity="0.45"/>
+  <circle cx="64" cy="78" r="20" fill="none" stroke="url(#ripple)" stroke-width="2.5" opacity="0.7"/>
+  <circle cx="64" cy="78" r="8" fill="url(#ripple)" opacity="0.95"/>
+  <path d="M64 18 L64 44 M56 36 L64 44 L72 36" stroke="#eceff4" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" opacity="0.85"/>
+</svg>

--- a/packages/resurface/manifest.json
+++ b/packages/resurface/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Resurface",
+  "description": "Passive re-exposure to your past. Injects a section above Linked References on every journal page showing one bullet block per rung of a time-decay ladder (1d, 3d, 1w, 2w, 1mo, 2mo, 6mo, 1y, 2y, 5y, 10y).",
+  "author": "kendreaditya",
+  "repo": "kendreaditya/resurface",
+  "icon": "icon.svg",
+  "theme": false
+}


### PR DESCRIPTION
## Plugin: Resurface

Passive re-exposure to your past — injects a section above Linked References on every journal page listing one bullet block per rung of a time-decay ladder (`1d, 3d, 1w, 2w, 1mo, 2mo, 6mo, 1y, 2y, 5y, 10y`). Mission is emotional continuity and wisdom persistence, not SRS or search.

- **Repo:** https://github.com/kendreaditya/resurface
- **Author:** @kendreaditya

## How it works

On every journal page, Resurface queries blocks by `:block/created-at` (with a `:block/journal-day` fallback). Each rung picks the most substantive block written within ±3 days of that offset from the journal date, expanding to ±7d then ±14d before skipping. Blocks hydrate their child subtree, block-refs are resolved inline, and everything renders with the same DOM classes as native Linked References so the user's theme styles it automatically.

Nothing is tracked, nothing is scheduled. Stateless v1 — collapse state is the only persisted thing.

## Visual parity

Section DOM mirrors `ui.cljs:foldable` + `views.cljs:view-head` so the Resurfaced section is visually indistinguishable from the Linked References section it sits above:

- `.ls-foldable-title` / `.ls-foldable-content` + `.is-collapsed` CSS-Grid animated collapse.
- `.references-blocks-wrap` / `.references-blocks-item` card layout.
- `.ls-block` / `.block-main-container` / `.block-children-container` + absolute `.block-children-left-border` for native indent guides.
- Full inline coverage: `[[Page]]`, `#tag`, `#[[Multi Word]]`, `**bold**`, `*italic*`, `~~strike~~`, `__underline__`, `==highlight==`, `` `code` ``, `[label](url)`, `![alt](url)`, `[[label](url)]` hybrid, `((uuid))` block-refs (hydrated via `Editor.getBlock`).

Per-card rung label (`1d`, `6mo`, `1y`, etc.) is a Resurface-only addition — intentionally subtle, non-interactive.

## Checklist

- [x] Icon + manifest.
- [x] README explains what the plugin does and how to load it.
- [x] Release with `resurface.zip` attached (cutting once the marketplace PR lands or a reviewer requests — plugin currently installable from source via "Load unpacked plugin").