### PR TITLE
feat: Add Logseq DB Favorite Tree 

### DIFF
--- a/packages/logseq-db-favorite-tree /icon.svg
+++ b/packages/logseq-db-favorite-tree /icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256" viewBox="0 0 256 256" fill="none">
+  <defs>
+    <linearGradient id="bg" x1="36" y1="28" x2="214" y2="228" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2563EB"/>
+      <stop offset="1" stop-color="#0EA5E9"/>
+    </linearGradient>
+    <linearGradient id="badge" x1="152" y1="136" x2="211" y2="195" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FDE68A"/>
+      <stop offset="1" stop-color="#F59E0B"/>
+    </linearGradient>
+  </defs>
+  <rect width="256" height="256" rx="56" fill="url(#bg)"/>
+  <path d="M48 82C48 68.745 58.745 58 72 58H110L130 80H184C197.255 80 208 90.745 208 104V182C208 195.255 197.255 206 184 206H72C58.745 206 48 195.255 48 182V82Z" fill="white" fill-opacity="0.96"/>
+  <path d="M48 94C48 85.163 55.163 78 64 78H112.059C117.364 78 122.452 80.107 126.201 83.858L136.343 94H192C200.837 94 208 101.163 208 110V114H48V94Z" fill="#DBEAFE"/>
+  <path d="M128 111V159" stroke="#2563EB" stroke-width="12" stroke-linecap="round"/>
+  <path d="M128 126H96" stroke="#2563EB" stroke-width="12" stroke-linecap="round"/>
+  <path d="M128 126H161" stroke="#2563EB" stroke-width="12" stroke-linecap="round"/>
+  <path d="M128 159H106" stroke="#2563EB" stroke-width="12" stroke-linecap="round"/>
+  <circle cx="94" cy="126" r="13" fill="#38BDF8"/>
+  <circle cx="163" cy="126" r="13" fill="#38BDF8"/>
+  <circle cx="104" cy="159" r="13" fill="#38BDF8"/>
+  <circle cx="128" cy="99" r="13" fill="#2563EB"/>
+  <circle cx="180" cy="170" r="29" fill="url(#badge)"/>
+  <path d="M180 151L185.29 161.714L197 163.416L188.5 171.701L190.507 183.368L180 177.844L169.493 183.368L171.5 171.701L163 163.416L174.71 161.714L180 151Z" fill="white"/>
+</svg>

--- a/packages/logseq-db-favorite-tree /manifest.json
+++ b/packages/logseq-db-favorite-tree /manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "DB Favorite Tree",
+  "description": "Render favorite pages as a property-driven tree for Logseq DB graph.",
+  "author": "yanhaizhe",
+  "repo": "yanhaizhe/logseq-db-favorite-tree",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}

--- a/packages/logseq-db-favorite-tree /manifest.json
+++ b/packages/logseq-db-favorite-tree /manifest.json
@@ -8,5 +8,6 @@
   "web": false,
   "effect": false,
   "supportsDB": true,
-  "supportsDBOnly": true
+  "supportsDBOnly": true,
+  "version": "1.1.0"
 }


### PR DESCRIPTION

## [1.1.0] - 2026-04-27

### Added

- Native sidebar tree mode integrated into Logseq's left sidebar
- Search, locate-current-page, expand/collapse all, refresh, and settings actions in sidebar mode
- Display mode preset setting with `sidebar`, `floating`, and `mixed`
- Search keyword highlighting in both floating panel and native sidebar
- Graph-scoped persistence for display mode, controls state, sorting, expanded nodes, and layout
- Refreshed icons and tooltip hints for action buttons

### Changed

- Default display preset is now `sidebar`
- `mixed` mode now initializes with sidebar shown first
- Leaf nodes no longer show misleading expand/collapse toggles
- Sidebar and floating UIs are now mutually exclusive instead of rendering together
- Sidebar mode now aligns more closely with native Logseq visual patterns

### Fixed

- Sidebar node expand/collapse actions not responding
- Sidebar page opening actions not responding
- Sidebar search input not taking effect
- Sidebar search losing focus after every keystroke
- Search-result trees not respecting manual collapse/expand in either mode
- Floating-only preset leaving sidebar UI behind
- Tooltip layering issues where action hints could be covered by later content

## [1.0.0] - 2026-04-27

### Added

- Initial public release of `Logseq DB Favorite Tree`
- Property-driven hierarchy tree built from favorite pages
- Floating panel, floating bubble, search, locate-current-page, sorting, and refresh controls
- DB graph support with file graph explicitly unsupported
---
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** [logseq-db-favorite-tree](https://github.com/yanhaizhe/logseq-db-favorite-tree)

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

> ⚠️ <i>The new incoming plugin recommended fields in [manifest.json](https://github.com/logseq/marketplace?tab=readme-ov-file#how-to-submit-your-plugin):</i>  
> `supportsDB` - [optional] Whether the plugin supports database graph.   
> `supportsDBOnly` - [optional] Whether the plugin only supports database graph.
