### PR TITLE
add logseq-prune-to-page plugin

### DIFF
--- a/packages/logseq-prune-to-page/icon.svg
+++ b/packages/logseq-prune-to-page/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="6" y="10" width="24" height="44" rx="3" fill="#6366f1"/>
+  <rect x="34" y="10" width="24" height="44" rx="3" fill="#a5b4fc"/>
+  <path d="M22 32 L42 32 M36 26 L42 32 L36 38" stroke="#fff" stroke-width="3" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/logseq-prune-to-page/manifest.json
+++ b/packages/logseq-prune-to-page/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Prune to Page",
+  "description": "Move selected blocks from your journal to a page of your choice, leaving block refs behind so journal provenance is preserved.",
+  "author": "vincent",
+  "repo": "vincentiliano/logseq_prune_to_page",
+  "icon": "./icon.svg",
+  "theme": false
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** [logseq_prune_to_page](https://github.com/vincentiliano/logseq_prune_to_page)

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

> ⚠️ <i>The new incoming plugin recommended fields in [manifest.json](https://github.com/logseq/marketplace?tab=readme-ov-file#how-to-submit-your-plugin):</i>  
> `supportsDB` - [optional] Whether the plugin supports database graph.   
> `supportsDBOnly` - [optional] Whether the plugin only supports database graph.
