### PR TITLE
Update Block to Page DB metadata

### DIFF
--- a/packages/logseq-block-to-page-db/manifest.json
+++ b/packages/logseq-block-to-page-db/manifest.json
@@ -4,6 +4,8 @@
   "author": "EINDEX",
   "repo": "eindex/logseq-plugin-block-to-page-db",
   "icon": "./icon.svg",
+  "sponsors": ["https://github.com/sponsors/EINDEX"],
+  "web": true,
   "supportsDB": true,
   "supportsDBOnly": true
 }


### PR DESCRIPTION
Plugin GitHub repo URL: https://github.com/EINDEX/logseq-plugin-block-to-page-db

Updates:
- Marks Block to Page DB as web supported.
- Adds the EINDEX GitHub Sponsors link.

Field validation:
- Uses only manifest fields listed by the logseq/marketplace README: sponsors, web, supportsDB, and supportsDBOnly are official optional fields.