### PR TITLE
Add Coding CLI Monitor plugin

### DIFF
--- a/packages/logseq-coding-cli-monitor/icon.svg
+++ b/packages/logseq-coding-cli-monitor/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#1f2a26"/>
+  <path d="M18 22l-8 10 8 10M46 22l8 10-8 10" fill="none" stroke="#9cc8b2" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M37 16L27 48" fill="none" stroke="#e8d8a8" stroke-width="5" stroke-linecap="round"/>
+</svg>

--- a/packages/logseq-coding-cli-monitor/manifest.json
+++ b/packages/logseq-coding-cli-monitor/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Coding CLI Monitor",
+  "description": "Monitor wrapped coding CLI sessions and surface working or attention states in Logseq.",
+  "author": "Kristin Day",
+  "repo": "Day-in-the-Country-LLC/logseq-coding-cli-monitor",
+  "icon": "./icon.svg",
+  "effect": true
+}


### PR DESCRIPTION
## Summary
Adds the Coding CLI Monitor plugin to the Logseq marketplace.

## Plugin Repo
- https://github.com/Day-in-the-Country-LLC/logseq-coding-cli-monitor

## Release
- https://github.com/Day-in-the-Country-LLC/logseq-coding-cli-monitor/releases/tag/v0.1.1

## Notes
- This plugin uses  because it mounts a host-level dock/panel inside Logseq.
- The plugin UI is distributed through the marketplace; the local helper/wrapper is run from the installed plugin folder.
- The README explains helper setup and usage.
