### PR TITLE
feat: add logseq-child-counter plugin

### DIFF
--- a/packages/logseq-child-counter/manifest.json
+++ b/packages/logseq-child-counter/manifest.json
@@ -1,0 +1,19 @@
+{
+  "name": "logseq-child-counter",
+  "version": "1.0.1",
+  "main": "index.html",
+  "description": "Displays the number of child blocks next to the parent block with a clean Soft UI approach.",
+  "author": "Amilcar",
+  "repo": "https://github.com/sobeitnow0/logseq-child-counter/upload/main",
+  "logseq": {
+    "id": "logseq-child-counter",
+    "title": "Child Counter",
+    "icon": "",
+    "theme": false,
+    "sponsors": [],
+    "web": false,
+    "effect": false,
+    "supportsDB": true,
+    "supportsDBOnly": false
+  }
+}


### PR DESCRIPTION
his PR adds the `logseq-child-counter` plugin to the marketplace. 

It provides a clean, non-intrusive UI element that displays the number of child blocks next to the parent block. It helps users navigate dense hierarchies without expanding blocks unnecessarily.

Key details:
- **Supports DB version:** Yes (`supportsDB: true`)
- **Sandbox Safe:** Yes (`effect: false`)

Thank you!