### PR TITLE
Add Clean Empty Journals

### DIFF
--- a/packages/logseq-clean-journals/manifest.json
+++ b/packages/logseq-clean-journals/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Clean Empty Journals",
+  "description": "Removes empty journal pages from your Logseq graph with a single toolbar click.",
+  "author": "Rino",
+  "repo": "rinodrops/logseq-clean-journals",
+  "icon": "icon.png",
+  "theme": false
+}


### PR DESCRIPTION
Adds a new plugin package: **Clean Empty Journals**.

- Repo: https://github.com/rinodrops/logseq-clean-journals
- Latest release: https://github.com/rinodrops/logseq-clean-journals/releases/tag/v0.3.0
- Description: Removes empty journal pages from your Logseq graph with a single toolbar click.

The release zip (`logseq-clean-journals-0.3.0.zip`) is attached to the v0.3.0 release.