### PR TITLE
Add Callout Manager plugin

### DIFF
--- a/packages/logseq-danzu-callout/manifest.json
+++ b/packages/logseq-danzu-callout/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Callout Manager",
+  "description": "Tag-driven callout styling for Logseq blocks — icons, labels, colored backgrounds with nested visual hierarchy. Four display modes (inline, container, icon, admonition), 28 predefined tags across 7 color groups, with optional cascade-to-children. DB graphs only.",
+  "author": "Danzu",
+  "repo": "hdansou/Logseq-callout",
+  "icon": "./icon.svg",
+  "theme": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
## Summary

- Tag-driven callouts: type `#warning`, `#tip`, `#note`, `#snippet`, `#search`, etc. and your blocks instantly get themed icons, labels, and colored backgrounds — no markup, no setup.
- Four display modes covering the full spectrum: minimal accent bar (admonition), GitHub-style left border (icon), tinted inline band (inline), and fully bordered admonition box (container).
- 28 predefined callout tags across 7 color groups, slash commands for every type, optional cascade to nested child blocks.

## Plugin

- **Repo:** https://github.com/hdansou/Logseq-callout
- **Release:** v1.0.0 (zip attached) — https://github.com/hdansou/Logseq-callout/releases/tag/v1.0.0
- **DB graphs only:** `supportsDB: true`, `supportsDBOnly: true`, `minSDKVersion: "0.3.2"`
- **README:** includes screenshots of all four display modes in action.

## Manifest

```json
{
  "title": "Callout Manager",
  "description": "Tag-driven callout styling for Logseq blocks — icons, labels, colored backgrounds with nested visual hierarchy. Four display modes (inline, container, icon, admonition), 28 predefined tags across 7 color groups, with optional cascade-to-children. DB graphs only.",
  "author": "Danzu",
  "repo": "hdansou/Logseq-callout",
  "icon": "./icon.svg",
  "theme": false,
  "supportsDB": true,
  "supportsDBOnly": true
}
```

## Pre-submission checklist

- [x] Release tag with zip attached (in addition to "Source code")
- [x] README clearly explains what the plugin does and how to use it
- [x] README includes screenshots showing the plugin in action (one per display mode)