### PR TITLE
Add OutlineCanvas plugin

### DIFF
--- a/packages/outline-canvas/manifest.json
+++ b/packages/outline-canvas/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "OutlineCanvas",
+  "description": "Renders hierarchical block trees as 8 interactive Canvas2D diagrams: Tree Chart, Tree Table, Roadmap (alternating), Roadmap (linear), Mind Map, Right Tree, Fishbone, and Treemap.",
+  "author": "logseq-dev",
+  "repo": "hdansou/logseq-outline-canvas",
+  "icon": "icon.png",
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
## Summary

- Renders hierarchical block trees as 8 interactive Canvas2D diagrams (Tree Chart, Tree Table, Roadmap ↕/→, Mind Map, Right Tree, Fishbone, Treemap).
- Two display modes: docked alongside the right sidebar, or full-screen overlay. Toggle via toolbar / `Cmd+Shift+O`.
- Inline `{{renderer :outline-canvas[, <view>]}}` macro embeds static PNG previews; click to open the interactive canvas.

## Plugin

- **Repo:** https://github.com/hdansou/logseq-outline-canvas
- **Release:** v1.0.0 (zip attached) — https://github.com/hdansou/logseq-outline-canvas/releases/tag/v1.0.0
- **DB graphs only:** `supportsDB: true`, `supportsDBOnly: true` (built against `@logseq/libs@^0.3.3`).
- **README:** includes screenshot and animated demo of the plugin in action.

## Manifest

```json
{
  "title": "OutlineCanvas",
  "description": "Renders hierarchical block trees as 8 interactive Canvas2D diagrams: Tree Chart, Tree Table, Roadmap (alternating), Roadmap (linear), Mind Map, Right Tree, Fishbone, and Treemap.",
  "author": "logseq-dev",
  "repo": "hdansou/logseq-outline-canvas",
  "icon": "icon.png",
  "effect": true,
  "supportsDB": true,
  "supportsDBOnly": true
}
```

## Pre-submission checklist

- [x] Release tag with zip attached (in addition to "Source code")
- [x] README clearly explains what the plugin does and how to use it
- [x] README includes a screenshot showing the plugin in action