### PR TITLE
Add Scheduler plugin

### DIFF
--- a/packages/logseq-scheduler/manifest.json
+++ b/packages/logseq-scheduler/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Scheduler",
+  "description": "Cron-based scheduler for creating tagged pages in Logseq DB graphs on a recurring basis",
+  "author": "Danzu",
+  "repo": "hdansou/Logseq-scheduler",
+  "icon": "./icon.svg",
+  "theme": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
## Summary

Adds **Scheduler** — a cron-based page creation plugin for Logseq DB graphs.

- Define recurring schedules in natural language (e.g. "every Saturday at 11 AM")
- Automatic date-suffixed pages with tags applied as page classes
- Missed-run catch-up, graph-scoped schedules, two-pane manager UI
- DB-graph only (`supportsDBOnly: true`)

## Plugin info

- **Author:** Danzu
- **Repo:** [hdansou/Logseq-scheduler](https://github.com/hdansou/Logseq-scheduler)
- **Release:** [v1.0.0](https://github.com/hdansou/Logseq-scheduler/releases/tag/v1.0.0)
- **Min SDK:** `@logseq/libs@0.3.2`

## Manifest

```json
{
  "title": "Scheduler",
  "description": "Cron-based scheduler for creating tagged pages in Logseq DB graphs on a recurring basis",
  "author": "Danzu",
  "repo": "hdansou/Logseq-scheduler",
  "icon": "./icon.svg",
  "theme": false,
  "supportsDB": true,
  "supportsDBOnly": true
}
```