### PR TITLE
Fix Outline Canvas manifest title and author

### DIFF
--- a/packages/outline-canvas/manifest.json
+++ b/packages/outline-canvas/manifest.json
@@ -1,7 +1,7 @@
 {
-  "title": "OutlineCanvas",
+  "title": "Outline Canvas",
   "description": "Renders hierarchical block trees as 8 interactive Canvas2D diagrams: Tree Chart, Tree Table, Roadmap (alternating), Roadmap (linear), Mind Map, Right Tree, Fishbone, and Treemap.",
-  "author": "logseq-dev",
+  "author": "Danzu",
   "repo": "hdansou/logseq-outline-canvas",
   "icon": "icon.png",
   "effect": true,


### PR DESCRIPTION
Follow-up to #794.

The merged manifest had the wrong `title` and `author`:

- `title`: `"OutlineCanvas"` → `"Outline Canvas"` (display name with a space, matching how the plugin should appear in the marketplace listing)
- `author`: `"logseq-dev"` → `"Danzu"` (matches the author field in the upstream repo's `package.json` and the plugin's actual maintainer)

No other fields are touched.