### PR TITLE
Add Logseq Library Display plugin

### DIFF
--- a/packages/logseq-library-display/manifest.json
+++ b/packages/logseq-library-display/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Logseq Library Display",
+  "description": "Display Logseq DB parent pages on page references.",
+  "author": "rien7",
+  "repo": "rien7/logseq-library-display",
+  "icon": "icon.svg",
+  "theme": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/rien7/logseq-library-display

## GitHub releases checklist

- [x] a legal package.json file.
- [x] a valid CI workflow build action for Github releases.
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase.
- [x] a license in the LICENSE file.

This plugin supports Logseq DB graphs only and marks `supportsDB` / `supportsDBOnly` in manifest.json.