### PR TITLE
Add Typst Formula plugin

### DIFF
--- a/packages/logseq-typst-formula/manifest.json
+++ b/packages/logseq-typst-formula/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Typst Formula",
+  "description": "Render Logseq blocks tagged with #Typst as centered Typst math formulas.",
+  "author": "ThreeIce",
+  "repo": "ThreeIce/logseq-typst-formula",
+  "icon": "icon.svg",
+  "web": true,
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
## Summary
- Add Typst Formula plugin manifest
- Plugin renders DB graph blocks tagged with #Typst as centered Typst math formulas

## Plugin repository
https://github.com/ThreeIce/logseq-typst-formula

## Release
https://github.com/ThreeIce/logseq-typst-formula/releases/tag/v0.1.0