### PR TITLE
fix: manifest for tabsdb plugin

### DIFF
--- a/packages/logseq-tabsdb-plugin/manifest.json
+++ b/packages/logseq-tabsdb-plugin/manifest.json
@@ -6,6 +6,6 @@
   "repo": "benjypng/logseq-tabsdb-plugin",
   "icon": "./icon.svg",
   "supportsDb": true,
-  "supportsDbOnly": true
-  "effect": true,
+  "supportsDbOnly": true,
+  "effect": true
 }


### PR DESCRIPTION
Fix: invalid `json` in `manifest.json` for logseq-tabsdb-plugin.