### PR TITLE
Remember My Block Plugin: Add 'effect' property to manifest.json

### DIFF
--- a/packages/logseq-plugin-remember-my-block/manifest.json
+++ b/packages/logseq-plugin-remember-my-block/manifest.json
@@ -5,5 +5,6 @@
     "repo": "PaulNoth/logseq-remember-my-block",
     "icon": "icon.svg",
     "theme": false,
+    "effect": true,
     "supportsDB": true
 }


### PR DESCRIPTION
# Enable `effect` on Remember My Block Plugin

During a testing marketplace version and long debugging I figured it out, that I need to enable `"effect": true"` to plugin to work properly

Similar plugins with `"effect": true"`:
* [Save scrollbar position](https://github.com/logseq/marketplace/blob/master/packages/logseq-save-scrollbar-position/manifest.json)
* [VIM shortcuts](https://github.com/logseq/marketplace/blob/master/packages/logseq-vim-shortcuts/manifest.json)

**Plugin GitHub repo URL:** https://github.com/PaulNoth/logseq-remember-my-block

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

