### PR TITLE
Sync KOReader Highlights: set effect:true in manifest

### DIFF
--- a/packages/sync-koreader-highlights/manifest.json
+++ b/packages/sync-koreader-highlights/manifest.json
@@ -3,5 +3,6 @@
   "description": "Sync KOReader sidecar highlights into Logseq, one page per book. Highlights link to the journal day they were made, so they appear in linked references automatically.",
   "author": "CR0CKER",
   "repo": "CR0CKER/sync-koreader-highlights",
-  "icon": "icon.png"
+  "icon": "icon.png",
+  "effect": true
 }


### PR DESCRIPTION
## Summary

Add `"effect": true` to the manifest for [Sync KOReader Highlights](https://github.com/CR0CKER/sync-koreader-highlights). Without it Logseq loads the plugin into an iframe sandbox that is cross-origin to the host, which:

- Blocks `window.showDirectoryPicker()` via Chromium's Permissions Policy.
- Strips user activation from toolbar clicks dispatched through Logseq's command bridge, so even the `<input type="file" webkitdirectory>` fallback throws `File chooser dialog can only be shown with a user activation`.
- Makes the host's `--ls-*` CSS variables unreadable from inside the plugin, so the panel can't pick up the active theme (including Awesome Styler accent / background overrides).

With `effect: true` Logseq picks the shadow-DOM sandbox and the plugin runs same-origin to the host. All three issues disappear.

Other plugins in this repo with comparable host-DOM needs already set this flag (e.g. `logseq-readwise-official-plugin`, `logseq-todo-plugin`, `logseq-awesome-styler`).

## Test plan

- [x] v0.1.3 of the plugin sets `"effect": true` in its own `package.json`, but the marketplace install overrides that with the manifest in this repo — currently `effect:false`, which breaks the picker and theming. Adding `"effect": true` here aligns the marketplace install with the bundled package.json.
- [x] Verified against three other plugins that use the same flag and run reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)