### PR TITLE
feat: add logseq-open-file-location plugin

### DIFF
--- a/packages/logseq-open-file-location/manifest.json
+++ b/packages/logseq-open-file-location/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Open File Location",
+  "description": "Ctrl+Click a local asset link to reveal and select it in the system file explorer.",
+  "author": "albilu",
+  "repo": "albilu/logseq-open-file-location",
+  "icon": "",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": false,
+  "supportsDBOnly": false
+}


### PR DESCRIPTION
## Plugin submission: Open File Location

**Repository:** https://github.com/albilu/logseq-open-file-location  
**Release:** https://github.com/albilu/logseq-open-file-location/releases/tag/v0.1.0

### Description

Ctrl+Click a local asset link to reveal and select it in the system file explorer.

### Checklist

- [x] Release has a zip file attached (`logseq-open-file-location.zip`)
- [x] README clearly describes what the plugin does and how to use it
- [x] README includes a GIF showing the plugin in action
- [x] `manifest.json` is present with all required fields
- [x] `theme: false`, `web: false`, `effect: false`
