### PR TITLE
Add Serendipity and Sequoia themes

### DIFF
--- a/packages/sequoia/manifest.json
+++ b/packages/sequoia/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "Sequoia",
+  "description": "Black, elegant Sequoia theme family for Logseq (Moonlight, Monochrome, Retro).",
+  "author": "Micheal Andreuzza",
+  "repo": "Sequoia-Theme/logseq",
+  "theme": true
+}

--- a/packages/serendipity/manifest.json
+++ b/packages/serendipity/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "Serendipity",
+  "description": "Elegant, minimal Serendipity theme family for Logseq (Midnight, Morning, Sunset).",
+  "author": "Micheal Andreuzza",
+  "repo": "Serendipity-Theme/logseq",
+  "theme": true
+}


### PR DESCRIPTION
## Summary
Lists Serendipity and Sequoia Logseq theme repos in the marketplace.

- Serendipity-Theme/logseq — Midnight, Morning, Sunset CSS themes
- Sequoia-Theme/logseq — Moonlight, Monochrome, Retro (dark + light)

## Test plan
- [ ] Marketplace shows both themes after merge
- [ ] CSS imports apply correctly in Logseq

Made with [Cursor](https://cursor.com)