### PR TITLE
Add plugin: Template Buttons (v0.1.1)

### DIFF
--- a/packages/logseq-template-buttons/README.md
+++ b/packages/logseq-template-buttons/README.md
@@ -1,0 +1,14 @@
+# Template Buttons
+
+Create Logseq pages from your templates with one click — from the left sidebar or from the current page (child page + backlink).
+
+## Features
+
+- Sidebar section above Favorites
+- Page bar menu for child pages with backlinks
+- Configurable JSON button list (templates and optional shell commands)
+- Full template content insertion (all blocks under `template::`)
+
+## Repository
+
+https://github.com/the-homeless-god/logseq-template-buttons

--- a/packages/logseq-template-buttons/README.md
+++ b/packages/logseq-template-buttons/README.md
@@ -1,13 +1,30 @@
 # Template Buttons
 
-Create Logseq pages from your templates with one click — from the left sidebar or from the current page (child page + backlink).
+<p align="center">
+  <img src="https://github.com/the-homeless-god/logseq-template-buttons/raw/main/docs/screenshots/logo.png" alt="Template Buttons" width="96" height="96" />
+</p>
+
+Create Logseq pages from your templates with one click — sidebar, page bar (child pages + backlink), git/terminal commands, and social markdown copy.
+
+**Latest release:** [v0.1.1](https://github.com/the-homeless-god/logseq-template-buttons/releases/tag/v0.1.1)
 
 ## Features
 
 - Sidebar section above Favorites
-- Page bar menu for child pages with backlinks
-- Configurable JSON button list (templates and optional shell commands)
+- Page bar: child pages, backlink on parent, copy social markdown
+- Template, command, git, and terminal button types
+- Localizable UI (`en` / `ru` presets + custom JSON labels)
 - Full template content insertion (all blocks under `template::`)
+
+## Screenshots
+
+| Overview | Settings |
+| --- | --- |
+| ![Overview](https://github.com/the-homeless-god/logseq-template-buttons/raw/main/docs/screenshots/overview.png) | ![Settings](https://github.com/the-homeless-god/logseq-template-buttons/raw/main/docs/screenshots/settings.png) |
+
+| Page bar | Copy social |
+| --- | --- |
+| ![Page bar](https://github.com/the-homeless-god/logseq-template-buttons/raw/main/docs/screenshots/pagebar-child-button.png) | ![Copy](https://github.com/the-homeless-god/logseq-template-buttons/raw/main/docs/screenshots/copy-social.png) |
 
 ## Repository
 

--- a/packages/logseq-template-buttons/manifest.json
+++ b/packages/logseq-template-buttons/manifest.json
@@ -1,0 +1,13 @@
+{
+  "title": "Template Buttons",
+  "description": "Sidebar and page-bar buttons to create pages from Logseq templates, including child pages with backlinks.",
+  "author": "Marat Zimnurov",
+  "repo": "the-homeless-god/logseq-template-buttons",
+  "icon": "icon.png",
+  "theme": false,
+  "sponsors": [],
+  "web": false,
+  "effect": true,
+  "supportsDB": false,
+  "supportsDBOnly": false
+}

--- a/plugins.json
+++ b/plugins.json
@@ -5072,6 +5072,21 @@
       "addedAt": 1642406539000
     },
     {
+      "title": "Template Buttons",
+      "description": "Sidebar and page-bar buttons to create pages from Logseq templates, including child pages with backlinks.",
+      "author": "Marat Zimnurov",
+      "repo": "the-homeless-god/logseq-template-buttons",
+      "icon": "icon.png",
+      "theme": false,
+      "sponsors": [],
+      "web": false,
+      "effect": true,
+      "supportsDB": false,
+      "supportsDBOnly": false,
+      "id": "logseq-template-buttons",
+      "addedAt": 1780241807110
+    },
+    {
       "title": "Tenset Security",
       "description": "Beautiful theme made for smart contract auditors",
       "author": "Tenset",


### PR DESCRIPTION
## Summary

Adds **Template Buttons** by Marat Zimnurov — sidebar and page-bar actions to create Logseq pages from `template::` blocks, child pages with backlinks, git/terminal commands, and social markdown copy.

- Plugin repo: https://github.com/the-homeless-god/logseq-template-buttons
- Release: https://github.com/the-homeless-god/logseq-template-buttons/releases/tag/v0.1.1
- `effect: true` (sidebar DOM + optional shell / terminal commands)
- Localizable UI: English default, Russian preset, custom JSON labels

## GitHub releases checklist

- [x] Legal `package.json` with `logseq` block
- [x] CI workflow `.github/workflows/publish.yml` on tag push
- [x] CI tests `.github/workflows/test.yml` (100% line coverage)
- [x] GitHub Release `v0.1.1` with zip from CI
- [x] README with screenshots and settings documentation
- [x] LICENSE file (BSD 3-Clause + commercial terms)
- [x] Marketplace icon (`icon.png` in plugin repo)

## Marketplace manifest

- `packages/logseq-template-buttons/manifest.json`
- `supportsDB: false`, `supportsDBOnly: false`

## Test plan

- [x] Maintainer: verify manifest builds in marketplace CI
- [x] Install from marketplace / release zip on Logseq desktop 0.10+
- [x] Sidebar Templates section appears above Favorites
- [x] Page bar branch menu creates child page + backlink
- [x] UI language `ru` / custom labels in plugin settings
- [x] Copy social markdown button on post pages