### PR TITLE
`logseq-reference-manager`: update manifest.json to run the plugin with `file://` origin

### DIFF
--- a/packages/logseq-reference-manager/manifest.json
+++ b/packages/logseq-reference-manager/manifest.json
@@ -4,6 +4,7 @@
   "author": "Rahul Somani",
   "repo": "rsomani95/logseq-reference-manager",
   "icon": "icon.svg",
+  "effect": true,
   "supportsDB": true,
   "supportsDBOnly": true
 }


### PR DESCRIPTION
This plugin initially failed when installed on the marketplace because of CORS issues making it impossible to speak to the Zotero API. That's essentially resolved in [this PR](https://github.com/logseq/logseq/pull/12753), but I need to run this plugin with `effect: true`, because I need to read PDF file contents to be able to extract annotations into Logseq's native format.

Some discussion in [this thread](https://discord.com/channels/725182569297215569/1511001964794744990/1511263292071346316) on Discord.