### PR TITLE
Add Google Agenda plugin

### DIFF
--- a/packages/logseq-google-agenda/manifest.json
+++ b/packages/logseq-google-agenda/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "Google Agenda",
+  "description": "Read-only Google Calendar and journal task month view for Logseq.",
+  "author": "albilu",
+  "repo": "albilu/logseq-google-agenda",
+  "icon": "icon.svg"
+}


### PR DESCRIPTION
## Summary
- add the logseq-google-agenda marketplace manifest
- point the listing to albilu/logseq-google-agenda
- include the plugin icon for marketplace display

## Verification
- release v1.0.0 includes the plugin zip asset
- local checks passed: npm test
- local checks passed: npm run build
