### PR TITLE
fix: Auto List Continuation — add DB-version note and set supportsDB

### DIFF
--- a/packages/logseq-auto-list/manifest.json
+++ b/packages/logseq-auto-list/manifest.json
@@ -1,11 +1,11 @@
 {
   "title": "Auto List Continuation",
-  "description": "Automatically continues bullet (-, *, +), numbered (1.), and lettered (a.) lists when pressing Shift+Enter inside a single block node. Keeps cohesive lists in one block without node bloat.",
+  "description": "Automatically continues bullet (-, *, +), numbered (1.), and lettered (a.) lists when pressing Shift+Enter inside a single block node. Keeps cohesive lists in one block without node bloat. Note: currently tested on the DB version only.",
   "author": "Xanaxus",
   "repo": "Xanaxus/Logseq-Auto-List",
   "icon": "./icon.png",
   "effect": true,
   "web": false,
-  "supportsDB": false,
+  "supportsDB": true,
   "supportsDBOnly": false
 }


### PR DESCRIPTION
Updates the manifest for **Auto List Continuation** (merged in #834).

### Changes
- `description`: appended `"Note: currently tested on the DB version only."` so users know the compatibility status upfront
- `supportsDB`: `false` → `true` — correctly signals the plugin is compatible with Logseq's DB version

No other files changed.