### PR TITLE
Add logseq-local-history plugin

### DIFF
--- a/packages/logseq-local-history/manifest.json
+++ b/packages/logseq-local-history/manifest.json
@@ -1,0 +1,10 @@
+{
+    "title": "Local History",
+    "description": "Track page changes in Logseq with local version history, diff view, and revert",
+    "author": "albilu",
+    "repo": "albilu/logseq-local-history",
+    "icon": "./icon.png",
+    "theme": false,
+    "web": false,
+    "effect": false
+}


### PR DESCRIPTION
Add Local History plugin

A Logseq plugin to track page changes with local version history, diff view, and revert capabilities.

**Repository:** https://github.com/albilu/logseq-local-history
**Release:** https://github.com/albilu/logseq-local-history/releases/tag/v0.1.0
**Screenshots:** https://raw.githubusercontent.com/albilu/logseq-local-history/master/screenshots/image.png

**Features:**
- Track Logseq page changes
- View history timestamps in the sidebar
- View differences between versions with diff view
- Undo/redo changes in diff view
- Revert to previous versions
- Configurable max versions per page

**Checklist**
- [x] Release has a zip file attached (logseq-local-history.zip)
- [x] README clearly describes what the plugin does and how to use it
- [x] README includes screenshots showing the plugin in action
- [x] manifest.json is present with all required fields
- [x] theme: false, web: false, effect: false