### PR TITLE
feat: add d2-renderer plugin

### DIFF
--- a/packages/d2-renderer/manifest.json
+++ b/packages/d2-renderer/manifest.json
@@ -1,0 +1,6 @@
+{
+  "title": "D2 Diagrams (WASM)",
+  "description": "Render D2 diagrams in fenced code blocks. Client-side WASM, no server required.",
+  "author": "edjeffreys",
+  "repo": "edjeffreys/logseq-d2"
+}


### PR DESCRIPTION
Note: this plugin exists to improve on the existing logseq-d2 plugin, to remove any network requests to `d2-api.fly.dev` to render the d2 diagrams; by instead utilising the official d2 WASM engine to ensure no network requests are made, and everything is rendered locally.

# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/edjeffreys/logseq-d2

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

> ⚠️ <i>The new incoming plugin recommended fields in [manifest.json](https://github.com/logseq/marketplace?tab=readme-ov-file#how-to-submit-your-plugin):</i>  
> `supportsDB` - [optional] Whether the plugin supports database graph.   
> `supportsDBOnly` - [optional] Whether the plugin only supports database graph.
