### PR TITLE
feat: add logseq-github-auto-sync plugin

### DIFF
--- a/packages/logseq-github-auto-sync/manifest.json
+++ b/packages/logseq-github-auto-sync/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "GitHub Auto Sync",
+  "description": "Encrypt and sync your Logseq graph to GitHub with automatic secret scanning. Tag files to encrypt them with age before push.",
+  "author": "Kada Liao",
+  "repo": "kadaliao/logseq-github-auto-sync",
+  "icon": "icon.svg",
+  "theme": false,
+  "effect": true,
+  "web": false,
+  "supportsDB": false
+}


### PR DESCRIPTION
Add GitHub Auto Sync plugin for encrypted Logseq sync

## Features
- Encrypts tagged files with age before syncing to GitHub
- Scans for secrets before push
- Git LFS support for large files
- Auto-sync with configurable intervals

## Author
Kada Liao (kadaliao@gmail.com)

## Repository
https://github.com/kadaliao/logseq-github-auto-sync