### PR TITLE
Add Table Formulas plugin

### DIFF
--- a/packages/logseq-table-formulas/icon.svg
+++ b/packages/logseq-table-formulas/icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect x="4" y="8" width="56" height="48" rx="6" fill="#2d6a4f"/>
+  <line x1="4" y1="24" x2="60" y2="24" stroke="#b7e4c7" stroke-width="3"/>
+  <line x1="4" y1="40" x2="60" y2="40" stroke="#b7e4c7" stroke-width="3"/>
+  <line x1="32" y1="8" x2="32" y2="56" stroke="#b7e4c7" stroke-width="3"/>
+  <text x="12" y="20" font-family="monospace" font-size="12" fill="#ffffff">fx</text>
+  <text x="40" y="53" font-family="monospace" font-size="14" fill="#ffffff">=</text>
+</svg>

--- a/packages/logseq-table-formulas/manifest.json
+++ b/packages/logseq-table-formulas/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Table Formulas",
+  "description": "Excel-like formulas in markdown tables: type =SUM(A1:A3) in a cell and the result shows up next to it. ~400 Excel functions, source text is never modified.",
+  "author": "Aleksandr Dmitriuk",
+  "repo": "eqeka/logseq-table-formulas",
+  "icon": "icon.svg",
+  "effect": true
+}

--- a/packages/logseq-table-formulas/manifest.json
+++ b/packages/logseq-table-formulas/manifest.json
@@ -1,6 +1,6 @@
 {
   "title": "Table Formulas",
-  "description": "Excel-like formulas in markdown tables: type =SUM(A1:A3) in a cell and the result shows up next to it. ~400 Excel functions, source text is never modified.",
+  "description": "Spreadsheet formulas in markdown tables: type =SUM(A1:A3) in a cell and the result shows up next to it. ~400 functions, source text is never modified.",
   "author": "Aleksandr Dmitriuk",
   "repo": "eqeka/logseq-table-formulas",
   "icon": "icon.svg",


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/eqeka/logseq-table-formulas

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases.
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (English, with screenshot)
- [x] a license in the LICENSE file. (GPL-3.0)

## About the plugin

Spreadsheet formulas in markdown tables: type `=SUM(B2:B6)` in a table cell and the computed result is rendered next to the formula. Powered by HyperFormula (~400 functions). The plugin only decorates the rendered view — source markdown is never modified, so editing blocks is unaffected. Works with all existing tables out of the box.