### PR TITLE
Add Orbitals for Logseq Plugin

### DIFF
--- a/packages/Logseq-orbitals/manifest.json
+++ b/packages/Logseq-orbitals/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Orbitals",
+  "description": "Kanban, weekly planner with time box, Tana-style project tables, and calendar for your Logseq tasks — plus Gmail → task capture, Google Calendar overlay, and meeting prep.",
+  "author": "yfhuang7",
+  "repo": "yfhuang7/logseq-orbitals",
+  "icon": "icon.svg",
+  "sponsors": ["https://buymeacoffee.com/yufenasyourfriend"]
+}


### PR DESCRIPTION
Added manifest file for the Orbitals plugin with metadata.

# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/yfhuang7/logseq-orbitals

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

> ⚠️ <i>The new incoming plugin recommended fields in [manifest.json](https://github.com/logseq/marketplace?tab=readme-ov-file#how-to-submit-your-plugin):</i>  
> `supportsDB` - [optional] Whether the plugin supports database graph.   
> `supportsDBOnly` - [optional] Whether the plugin only supports database graph.
