### PR TITLE
Add Highlight Colorizer

### DIFF
--- a/packages/highlight-colorizer/manifest.json
+++ b/packages/highlight-colorizer/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Highlight Colorizer",
+  "description": "Color highlighted text with readable directives and a floating palette while editing Logseq blocks.",
+  "author": "TKnifer",
+  "repo": "TKnifer/logseq-highlight-colorizer",
+  "effect": true,
+  "sponsors": [],
+  "web": false,
+  "supportsDB": false,
+  "supportsDBOnly": false
+}


### PR DESCRIPTION
## Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/TKnifer/logseq-highlight-colorizer

## GitHub releases checklist

- [x] A legal `package.json` file.
- [x] A valid `publish.yml` GitHub Actions workflow for releases.
- [x] A `v0.1.2` release with a dedicated installable ZIP from a successful workflow run.
- [x] A clear English README with an image showcase.
- [x] An MIT `LICENSE` file.

## Plugin summary

Highlight Colorizer adds readable color directives such as `==<yellow>text==` and a floating palette while editing Logseq blocks. It uses effect mode to style rendered highlights and position the palette in the host document.

Release: https://github.com/TKnifer/logseq-highlight-colorizer/releases/tag/v0.1.2
