### PR TITLE
Add Voice Memo plugin

### DIFF
--- a/packages/logseq-voice-memo/icon.svg
+++ b/packages/logseq-voice-memo/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="64" height="64" fill="none" stroke="#e5484d" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="9" y="2" width="6" height="12" rx="3"/>
+  <path d="M5 10a7 7 0 0 0 14 0"/>
+  <line x1="12" y1="17" x2="12" y2="22"/>
+  <line x1="8" y1="22" x2="16" y2="22"/>
+</svg>

--- a/packages/logseq-voice-memo/manifest.json
+++ b/packages/logseq-voice-memo/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Voice Memo",
+  "description": "Record a voice memo from your microphone and inject it into Logseq as a playable MP3 or WAV asset.",
+  "author": "nnigmat",
+  "repo": "Nnigmat/logseq-plugin-voice-memo",
+  "icon": "icon.svg",
+  "effect": true
+}


### PR DESCRIPTION
Adds the Voice Memo plugin — record a voice memo from the microphone and inject it into Logseq as a playable MP3/WAV asset. Plugin repo: https://github.com/Nnigmat/logseq-plugin-voice-memo