### PR TITLE
Add Block Created Time plugin

### DIFF
--- a/packages/logseq-timestamp/icon.svg
+++ b/packages/logseq-timestamp/icon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Block Created Time">
+  <rect width="64" height="64" rx="14" fill="#5b8def"/>
+  <circle cx="32" cy="32" r="20" fill="none" stroke="#fff" stroke-width="5"/>
+  <path d="M32 20v13l9 6" fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-width="5"/>
+</svg>

--- a/packages/logseq-timestamp/manifest.json
+++ b/packages/logseq-timestamp/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Block Created Time",
+  "description": "Show compact creation timestamps beside blocks in Logseq DB graphs.",
+  "author": "Inchan Kang",
+  "repo": "vivanotica/logseq-timestamp",
+  "icon": "./icon.svg",
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/vivanotica/logseq-timestamp

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/vivanotica/logseq-timestamp/blob/main/.github/workflows/publish.yml) build action for GitHub releases.
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear English README with an image showcase.
- [x] a license in the LICENSE file.

## Compatibility

- `supportsDB`: true
- `supportsDBOnly`: true
- `effect`: true — required to add read-only timestamp badges to the host block DOM.
