### PR TITLE
Add Home OS Capture

### DIFF
--- a/packages/logseq-home-os-capture/icon.svg
+++ b/packages/logseq-home-os-capture/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Home OS</title>
+  <desc id="desc">The letter H constructed from four connected knowledge nodes</desc>
+  <rect width="128" height="128" rx="28" fill="#173f35"/>
+  <path d="M40 44v40M88 44v40M50 64h28" fill="none" stroke="#f4efe3" stroke-linecap="round" stroke-width="10"/>
+  <circle cx="40" cy="34" r="10" fill="#d9895b"/>
+  <circle cx="40" cy="94" r="10" fill="#d9895b"/>
+  <circle cx="88" cy="34" r="10" fill="#d9895b"/>
+  <circle cx="88" cy="94" r="10" fill="#d9895b"/>
+</svg>

--- a/packages/logseq-home-os-capture/manifest.json
+++ b/packages/logseq-home-os-capture/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Home OS Capture",
+  "description": "Turn photo-first journal captures into a private, structured home manual with guided setup and local Codex processing.",
+  "author": "ZeroShot or Die",
+  "repo": "AlienOctopus/logseq-home-os",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Adds Home OS Capture, a DB-graph-only plugin that turns photo-first `#HomeCapture` journal blocks into a private, structured home manual through a loopback-only local Codex companion.

Submission checklist:
- Public repository with MIT license and setup/use documentation
- `v0.8.1` GitHub release with a generated plugin zip attached
- Guided first-run setup plus a canonical-only **Find in Home OS** interface
- Finder queries only durable Home, Space, System, Item, and Document tags, deduplicates by UUID, and excludes captures, evidence, citations, and incidental mentions
- Clean human record titles; native DB tags remain the record-type authority
- First-class serial-number capture with conflict protection and value-free privacy auditing
- Clean-graph diagnostics defer record audits until schema setup completes instead of surfacing lower-level tag errors
- `supportsDB: true` and `supportsDBOnly: true`
- `effect`, `web`, and `theme` remain false
- Tested on Logseq 2.0.1 DB graphs on macOS
- Source captures remain read-only; the plugin does not access SQLite, WAL, sync, search, or db-worker files

Repository: https://github.com/AlienOctopus/logseq-home-os
Release: https://github.com/AlienOctopus/logseq-home-os/releases/tag/v0.8.1
