### PR TITLE
Add Gruvbox DB theme

### DIFF
--- a/packages/logseq-gruvbox-db/icon.svg
+++ b/packages/logseq-gruvbox-db/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title desc">
+  <title id="title">Gruvbox DB</title>
+  <desc id="desc">Three nested outline blocks in the Gruvbox palette.</desc>
+  <rect width="128" height="128" fill="#1d2021"/>
+  <rect x="8" y="8" width="112" height="112" rx="22" fill="#282828" stroke="#504945" stroke-width="4"/>
+  <path d="M28 42v52M28 68h16v26h16" fill="none" stroke="#665c54" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="28" cy="34" r="7" fill="#fabd2f"/>
+  <rect x="44" y="28" width="60" height="12" rx="6" fill="#ebdbb2"/>
+  <circle cx="44" cy="68" r="7" fill="#83a598"/>
+  <rect x="60" y="62" width="44" height="12" rx="6" fill="#d5c4a1"/>
+  <circle cx="60" cy="94" r="7" fill="#fe8019"/>
+  <rect x="76" y="88" width="28" height="12" rx="6" fill="#bdae93"/>
+</svg>

--- a/packages/logseq-gruvbox-db/manifest.json
+++ b/packages/logseq-gruvbox-db/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Gruvbox DB",
+  "description": "An opaque, adaptive Gruvbox light and dark theme for Logseq DB, with exact #Border block styling and a documented Tabs bridge.",
+  "author": "Shawn Salat",
+  "repo": "ThinkSalat/logseq-gruvbox-db",
+  "icon": "icon.svg",
+  "theme": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/ThinkSalat/logseq-gruvbox-db

## GitHub releases checklist

- [x] A legal `package.json` file.
- [x] A valid GitHub Actions release workflow.
- [x] A release that includes a ZIP package from a successful build.
- [x] A clear English README with sanitized dark and light image showcases.
- [x] An MIT `LICENSE` file.

## Summary

Adds **Gruvbox DB**, an effect-free, DB-only theme with coordinated light and
dark palettes. Both registered modes share one display name and one stylesheet,
so Logseq can follow the user's light, dark, or system appearance after the
theme is selected once in each mode.

- Release: https://github.com/ThinkSalat/logseq-gruvbox-db/releases/tag/v0.1.0
- Successful release workflow: https://github.com/ThinkSalat/logseq-gruvbox-db/actions/runs/30050173936
- Marketplace flags: `theme`, `supportsDB`, and `supportsDBOnly`

## Additional features disclosed in the README

- **`#Border` blocks:** the CSS matches only the exact rendered `#Border` tag
  name. It contains no graph-specific UUID or substring fallback, so tags such
  as `#Bordered` and `#Unbordered` do not match.
- **Tabs bridge:** because Tabs renders in a separate iframe, the repository
  includes an optional, manual, version-guarded helper for Tabs v1.19.4. It
  backs up before patching and warns that Tabs updates can overwrite it. The
  Gruvbox theme itself remains `effect: false` and never modifies Tabs
  automatically.

## Validation

- `npm run check`
- PowerShell 7 and Windows PowerShell 5.1 helper dry runs
- Headless light/dark CSS checks proving that only `#Border` matches while
  `#Bordered` and `#Unbordered` remain unchanged
- Downloaded the GitHub release ZIP, extracted it, and reran `npm run check`
  successfully
