### PR TITLE
feat: add History Timeline plugin (DB-only)

### DIFF
--- a/packages/logseq-history-timeline-plugin/icon.svg
+++ b/packages/logseq-history-timeline-plugin/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="3" y1="12" x2="21" y2="12"/><circle cx="7" cy="12" r="2" fill="currentColor"/><circle cx="15" cy="12" r="2" fill="currentColor"/></svg>

--- a/packages/logseq-history-timeline-plugin/manifest.json
+++ b/packages/logseq-history-timeline-plugin/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "History Timeline",
+  "description": "Turn #tl-tagged nodes into an interactive, zoomable historical timeline — eras, events and people, filterable by topic and type. DB graphs only.",
+  "author": "P. Kerim Friedman",
+  "repo": "kerim/logseq-history-timeline-plugin",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/kerim/logseq-history-timeline-plugin

Turns `#tl`-tagged nodes into an interactive, zoomable historical timeline — eras, events and people, filterable by topic and type, with click-through back to the source node. DB graphs only, so the manifest sets both `supportsDB` and `supportsDBOnly`.

The repo also ships a ready-made demo graph (60 world-history entries) importable from Logseq's Import menu, so reviewers and users can see it working without authoring any data first.

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases.
- [x] a release which includes a release zip pkg from a successful build — [v0.1.7](https://github.com/kerim/logseq-history-timeline-plugin/releases/tag/v0.1.7), asset `logseq-history-timeline-plugin-v0.1.7.zip`.
- [x] a clear README file, with a screenshot showcase.
- [x] a license in the LICENSE file (MIT).
