### PR TITLE
feat: add DB Banner plugin

### DIFF
--- a/packages/logseq-db-banner/manifest.json
+++ b/packages/logseq-db-banner/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "DB Banner",
+  "description": "Journal banner for Logseq DB graphs: a local wallpaper with a month calendar, day/week/year/life progress bars and a quote of the day.",
+  "author": "Asaki14",
+  "repo": "Asaki14/logseq-db-banner",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Adds **DB Banner**, a journal banner plugin for Logseq DB graphs.

It renders a banner at the top of a journal view: a wallpaper from the user's own machine, a month calendar whose days link to their journal pages and mark the ones holding content, day/week/year/life time-progress bars, and a quote of the day drawn from blocks tagged `Quote`.

- Repository: https://github.com/Asaki14/logseq-db-banner
- Release: https://github.com/Asaki14/logseq-db-banner/releases/tag/v0.2.0 (built by `publish.yml`, with `logseq-db-banner-v0.2.0.zip` attached)
- README shows what it does, how to configure it, and includes a screenshot of the plugin in action.

`supportsDBOnly` is `true`: `package.json` declares `logseq.unsupportedGraphType: "file"`, and the plugin also checks `logseq.App.checkCurrentIsDbGraph()` at startup and exits on a file graph. `effect` stays `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
