### PR TITLE
feat: add Journal Time Prefix plugin

### DIFF
--- a/packages/logseq-journal-time-prefix/manifest.json
+++ b/packages/logseq-journal-time-prefix/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Journal Time Prefix",
+  "description": "Automatically add a local time prefix to top-level blocks in Logseq DB journals.",
+  "author": "Asaki14",
+  "repo": "Asaki14/logseq-journal-time-prefix",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Adds **Journal Time Prefix**, a small plugin for Logseq DB graphs.

When a top-level block is written in a journal page, the plugin prefixes it with the local time, so a day's notes carry their own timeline. The prefix format is configurable — the brackets can be changed or removed — and pages, headings and tags can be excluded.

- Repository: https://github.com/Asaki14/logseq-journal-time-prefix
- Release: https://github.com/Asaki14/logseq-journal-time-prefix/releases/tag/v0.3.0 (built by `publish.yml`, with the packaged zip attached)
- README shows what it does, how to configure it, and includes a GIF of the prefix appearing while typing.

`supportsDBOnly` is `true`: `package.json` declares `logseq.unsupportedGraphType: "file"`. `effect` stays `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
