### PR TITLE
Add Kokoro TTS plugin

### DIFF
--- a/packages/logseq-kokoro-tts/manifest.json
+++ b/packages/logseq-kokoro-tts/manifest.json
@@ -1,0 +1,11 @@
+{
+  "title": "Kokoro TTS",
+  "description": "Speak selected Logseq DB blocks using a local Kokoro-compatible TTS server.",
+  "author": "Shriman Keshri",
+  "repo": "shrimansoft/logseq-kokoro-tts",
+  "icon": "icon.svg",
+  "theme": false,
+  "web": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Adds Kokoro TTS, a DB-version Logseq plugin that speaks selected blocks through a local Kokoro-compatible TTS server.\n\nPlugin repo: https://github.com/shrimansoft/logseq-kokoro-tts\nRelease: https://github.com/shrimansoft/logseq-kokoro-tts/releases/tag/v0.1.2