### PR TITLE
Add Sidebar Tabs DB plugin

### DIFF
--- a/packages/logseq-sidebar-tabs-db/icon.svg
+++ b/packages/logseq-sidebar-tabs-db/icon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <path fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.8" d="M3.5 4.5h17v15h-17zM14 4.5v15M5.8 7.2h2.7M9.8 7.2h2M16.2 7.5h2.2M16.2 11h2.2M16.2 14.5h2.2"/>
+</svg>

--- a/packages/logseq-sidebar-tabs-db/manifest.json
+++ b/packages/logseq-sidebar-tabs-db/manifest.json
@@ -1,0 +1,12 @@
+{
+  "title": "Sidebar Tabs for Logseq DB",
+  "description": "Turn Logseq DB's right-sidebar panels into tabs with leaf labels and persistent compact pins.",
+  "author": "Shawn Salat",
+  "repo": "ThinkSalat/logseq-sidebar-tabs-db",
+  "icon": "./icon.svg",
+  "theme": false,
+  "web": false,
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/ThinkSalat/logseq-sidebar-tabs-db

## What changed

Adds the DB-only **Sidebar Tabs for Logseq DB** plugin to the marketplace with
its icon and compatibility metadata.

The plugin turns existing right-sidebar panels into a tab bar, keeps Logseq's
native Contents/Page graph/Help controls above it, preserves identifying leaf
labels, and supports persistent compact pinned tabs.

## Why `effect: true` is required

The public plugin API does not provide a hook for enumerating and tabifying the
right-sidebar panels that Logseq has already rendered. The sandboxed entry
therefore uses Logseq's public `Experiments.loadScripts` bridge to install a
small host script.

That script only observes `#right-sidebar`, reads the rendered panel titles
needed for tab labels, stores pin identities in local browser storage, and
delegates closing to Logseq's native close buttons. It does not mutate private
application state or make network requests, and it removes its DOM,
observers, timers, classes, and ARIA changes when unloaded.

## Release

- Release: https://github.com/ThinkSalat/logseq-sidebar-tabs-db/releases/tag/v1.0.4
- Installable asset: https://github.com/ThinkSalat/logseq-sidebar-tabs-db/releases/download/v1.0.4/logseq-sidebar-tabs-db-v1.0.4.zip
- Release workflow: https://github.com/ThinkSalat/logseq-sidebar-tabs-db/actions/runs/30217729656

## Validation

- `npm test`
  - JavaScript syntax checks
  - SDK/bootstrap contract
  - sidebar DOM behavior
  - delayed creation and complete remount recovery
  - hierarchical and duplicate labels
  - keyboard focus and pin persistence
- Marketplace `scripts/build.mjs --build` produced the expected
  `logseq-sidebar-tabs-db` entry.
- The generated entry passes `bb validate-plugins`.
- The published zip was downloaded and verified to contain one plugin root
  with `package.json`, `index.js`, `host.js`, `icon.svg`, `README.md`, and
  `LICENSE`.

## GitHub releases checklist

- [x] A legal `package.json` file.
- [x] A tag-triggered GitHub Actions workflow that tests and builds releases.
- [x] A published release with a generated plugin zip asset.
- [x] A clear English README with a sanitized visual showcase.
- [x] An MIT `LICENSE` file.
- [x] `supportsDB: true` and `supportsDBOnly: true`.
