### PR TITLE
Add DB Activity Heatmap

### DIFF
--- a/packages/db-activity-heatmap/manifest.json
+++ b/packages/db-activity-heatmap/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "DB Activity Heatmap",
+  "description": "A toolbar heatmap showing how many blocks you create each day across a Logseq DB graph.",
+  "author": "vivanotica",
+  "repo": "vivanotica/logseq-plugin-heatmap",
+  "icon": "logo.png",
+  "effect": false,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
**Plugin GitHub repo URL:** https://github.com/vivanotica/logseq-plugin-heatmap

## Summary

Adds DB Activity Heatmap, a read-only toolbar heatmap that counts blocks
created each day across a Logseq DB graph.

The plugin supports DB graphs only and does not request the `effect`
permission.

## GitHub releases checklist

- [x] Legal `package.json`
- [x] Valid GitHub Actions release workflow
- [x] [v0.1.0 release with plugin ZIP](https://github.com/vivanotica/logseq-plugin-heatmap/releases/tag/v0.1.0)
- [x] Clear English README with a screenshot and usage instructions
- [x] MIT license in `LICENSE`

## Validation

- Manifest JSON parsed successfully
- Required manifest fields verified
- `effect: false`
- `supportsDB: true`
- `supportsDBOnly: true`
