### PR TITLE
fix(logseq-journal-time-prefix): correct effect flag to true

### DIFF
--- a/packages/logseq-journal-time-prefix/manifest.json
+++ b/packages/logseq-journal-time-prefix/manifest.json
@@ -6,7 +6,7 @@
   "icon": "icon.svg",
   "theme": false,
   "web": false,
-  "effect": false,
+  "effect": true,
   "supportsDB": true,
   "supportsDBOnly": true
 }


### PR DESCRIPTION
**Plugin GitHub repo URL:** https://github.com/Asaki14/logseq-journal-time-prefix

## Problem

`logseq-journal-time-prefix` currently ships with `"effect": false` in its `manifest.json` in this repo, but the plugin needs `effect: true` to work: it uses `window.parent.document` to reach the Logseq host document so it can prefix a timestamp onto the live editor textarea as the user types.

## Verified mechanism

A marketplace install rewrites the installed plugin's own `package.json` on disk, stamping this listing's `effect` value over whatever the release zip shipped. Logseq's runtime then reads that mutated on-disk value on every later start, so this listing is the actual authority — no change on the plugin's release side can override it.

With `effect: false`, the plugin's iframe is placed on `lsp://logseq.io` while the host page is `lsp://logseq.com`. Cross-origin, so `window.parent.document` throws and live editor prefixing never runs; users get a warning toast and only a committed-block fallback.

Tested in an isolated Logseq 2.0.1 instance: on the same installed v0.3.2 build, flipping only this one field to `true` in the on-disk `package.json` moved the iframe to `lsp://logseq.com`, and the time prefix appeared correctly on the first keystroke.

## Change

One field in `packages/logseq-journal-time-prefix/manifest.json`:

```diff
-  "effect": false,
+  "effect": true,
```

This matches the sibling listing `packages/logseq-db-banner/manifest.json`, which already uses `"effect": true`.

## GitHub releases checklist

- [x] a legal package.json file.
- [x] a valid CI workflow build action for GitHub releases.
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file (English and Chinese versions).
- [x] a license in the LICENSE file.
