### PR TITLE
enable effect for logseq-plus-minus-next

### DIFF
--- a/packages/logseq-plus-minus-next/manifest.json
+++ b/packages/logseq-plus-minus-next/manifest.json
@@ -7,7 +7,7 @@
   "theme": false,
   "sponsors": ["https://www.buymeacoffee.com/wiegi"],
   "web": false,
-  "effect": false,
+  "effect": true,
   "supportsDB": false,
   "supportsDBOnly": false,
   "id": "logseq-plus-minus-next"


### PR DESCRIPTION
Set effect: true so the plugin can intercept Enter key events in the Logseq editor. This prevents empty reflection entries from being outdented and unexpectedly creating an additional box in the Plus / Minus / Next board.
The built-in plugin API does not expose the required editor key event, so same-origin sandbox access is necessary.