### PR TITLE
feat: add logseq-nodebook plugin

### DIFF
--- a/packages/logseq-nodebook/manifest.json
+++ b/packages/logseq-nodebook/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "nodeBook",
+  "description": "CNL knowledge graphs from ```nodeBook fences: interactive concept maps, morphs, inference, containment view, and Petri-net token simulation.",
+  "repo": "gnowgi/logseq-nodebook",
+  "author": "gnowgi",
+  "icon": "icon.png",
+  "supportsDB": false,
+  "effect": true,
+  "sponsors": []
+}


### PR DESCRIPTION
## Which plugin?

**nodeBook** — render Controlled Natural Language knowledge graphs from ```nodeBook code fences.

- Plugin repo: https://github.com/gnowgi/logseq-nodebook
- Release with packaged zip: https://github.com/gnowgi/logseq-nodebook/releases/tag/v0.1.0

## What does it do?

Write knowledge as readable CNL in a code fence and get an interactive Cytoscape graph in the note: draggable concept maps with an inspector panel, polymorphic node states (morphs) switchable live, inferred relations (transitive is_a, membership inheritance) drawn with proof tooltips, a containment (nesting) view for class hierarchies, and Petri-net process notation with click-to-fire token simulation — useful for chemistry/biology/ecology teaching content. Uses `logseq.Experiments.registerFencedCodeRenderer` (host React) with the rendering engine loaded via `loadScripts`, same pattern as logseq-fenced-code-plus. Includes a `/nodeBook graph` slash command, PNG export, and an Edit button back to the source.

Built on the open-source npm packages [@nodebook/core](https://www.npmjs.com/package/@nodebook/core) and [@nodebook/dom](https://www.npmjs.com/package/@nodebook/dom) (AGPL-3.0).