### PR TITLE
Add logseq-plugin-paperless

### DIFF
--- a/packages/logseq-plugin-paperless/logo.svg
+++ b/packages/logseq-plugin-paperless/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#2b6cb0"/>
+  <path d="M9 7h10l4 4v14a1 1 0 0 1-1 1H9a1 1 0 0 1-1-1V8a1 1 0 0 1 1-1z" fill="#fff" fill-opacity="0.9"/>
+  <path d="M19 7v4h4" fill="none" stroke="#2b6cb0" stroke-width="1"/>
+  <path d="M11 16h8M11 19h8M11 22h5" stroke="#2b6cb0" stroke-width="1.4" stroke-linecap="round"/>
+</svg>

--- a/packages/logseq-plugin-paperless/manifest.json
+++ b/packages/logseq-plugin-paperless/manifest.json
@@ -1,0 +1,7 @@
+{
+  "title": "Paperless-ngx Links",
+  "description": "Insert links to paperless-ngx saved views and documents from Logseq.",
+  "author": "Dennis Waldherr",
+  "repo": "Bytekeeper/logseq-paperless",
+  "icon": "./logo.svg"
+}


### PR DESCRIPTION
Insert links to paperless-ngx saved views and documents from Logseq via slash commands.

Repo: https://github.com/Bytekeeper/logseq-paperless

# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** ________________

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases. (theme plugin for [this](https://github.com/Sansui233/logseq-bonofix-theme/blob/master/.github/workflows/publish.yml)).
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase. (For more friendly to users, it is recommended to have English version description).
- [x] a license in the LICENSE file.

> ⚠️ <i>The new incoming plugin recommended fields in [manifest.json](https://github.com/logseq/marketplace?tab=readme-ov-file#how-to-submit-your-plugin):</i>  
> `supportsDB` - [optional] Whether the plugin supports database graph.   
> `supportsDBOnly` - [optional] Whether the plugin only supports database graph.
