### PR TITLE
fix: nodeBook supports the DB version

### DIFF
--- a/packages/logseq-nodebook/manifest.json
+++ b/packages/logseq-nodebook/manifest.json
@@ -4,7 +4,7 @@
   "repo": "gnowgi/logseq-nodebook",
   "author": "gnowgi",
   "icon": "icon.png",
-  "supportsDB": false,
+  "supportsDB": true,
   "effect": true,
   "sponsors": []
 }


### PR DESCRIPTION
## Which plugin?

**nodeBook** (`packages/logseq-nodebook`) — updating my own listing (added in #881).

## What changed?

`supportsDB: false` → `true`. The flag was set conservatively at submission; the plugin has since been verified working on the Logseq DB version — it uses `registerFencedCodeRenderer` + host-page rendering and touches no file-graph-specific APIs (the schema-store page is created via the standard Editor API). With the flag false, DB-version users cannot see the plugin in the marketplace.