### PR TITLE
Add Simple Excalidraw DB Plugin

### DIFF
--- a/packages/logseq-simple-excalidraw-db/manifest.json
+++ b/packages/logseq-simple-excalidraw-db/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Simple Excalidraw DB",
+  "description": "Render and edit Excalidraw data stored directly on Logseq DB blocks.",
+  "author": "vivanotica",
+  "repo": "vivanotica/logseq-simple-excalidraw-db",
+  "icon": "logo.png",
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
## Plugin description

Simple Excalidraw DB renders and edits Excalidraw drawings stored directly on Logseq DB blocks. Drawing JSON and renderer height are stored as hidden properties on the same block, without creating drawing pages.

## Submission checklist

- Public repository: https://github.com/vivanotica/logseq-simple-excalidraw-db
- Release: https://github.com/vivanotica/logseq-simple-excalidraw-db/releases/tag/v0.1.0
- Release includes the installable plugin ZIP
- README includes usage, implementation details, and a demo GIF
- DB-only support is declared with `supportsDB` and `supportsDBOnly`
