### PR TITLE
Superseded by #886

### DIFF
--- a/packages/logseq-block-created-time/manifest.json
+++ b/packages/logseq-block-created-time/manifest.json
@@ -1,0 +1,10 @@
+{
+  "title": "Block Created Time",
+  "description": "Shows the creation time of every visible block in Logseq DB graphs.",
+  "author": "vivanotica",
+  "repo": "vivanotica/logseq-timestamp",
+  "icon": "icon.svg",
+  "effect": true,
+  "supportsDB": true,
+  "supportsDBOnly": true
+}


### PR DESCRIPTION
Closed because Block Created Time was already listed in the Marketplace.

The intended author-only metadata update is tracked in #886.
