### PR TITLE
Update Block Created Time author

### DIFF
--- a/packages/logseq-timestamp/manifest.json
+++ b/packages/logseq-timestamp/manifest.json
@@ -1,7 +1,7 @@
 {
   "title": "Block Created Time",
   "description": "Show compact creation timestamps beside blocks in Logseq DB graphs.",
-  "author": "Inchan Kang",
+  "author": "vivanotica",
   "repo": "vivanotica/logseq-timestamp",
   "icon": "./icon.svg",
   "effect": true,


### PR DESCRIPTION
Updates the author of the existing Block Created Time marketplace entry from `Inchan Kang` to `vivanotica`.

No plugin metadata or functionality is changed otherwise.
