### PR TITLE
Enable DB support for Logseq Timebox Calendar

### DIFF
--- a/packages/logseq-timebox/manifest.json
+++ b/packages/logseq-timebox/manifest.json
@@ -4,5 +4,5 @@
     "author": "yusuf",
     "repo": "yusuf8834/logseq-timebox",
     "icon": "./list-details.png",
-    "supportsDB": false
+    "supportsDB": true
 }


### PR DESCRIPTION
## Summary

- Set `supportsDB` to `true` for Logseq Timebox Calendar.
- Keep Markdown/Logseq OG support unchanged.

## Verification

- Marketplace-installed `v0.4.2` tested successfully in both Logseq DB and Logseq OG.
- DB task loading, task mutations, external calendars, persistent external-event caching, and OG compatibility were manually verified.
- The `v0.4.2` release workflow and packaged ZIP passed verification.

Release: https://github.com/yusuf8834/logseq-timebox/releases/tag/v0.4.2