### PR TITLE
Add Tennis Capture (logseq-live-tennis)

### DIFF
--- a/packages/logseq-live-tennis/logo.svg
+++ b/packages/logseq-live-tennis/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <defs>
+    <radialGradient id="ball" cx="0.35" cy="0.3" r="0.9">
+      <stop offset="0" stop-color="#e8f76f"/>
+      <stop offset="1" stop-color="#b7d332"/>
+    </radialGradient>
+  </defs>
+  <rect x="2" y="2" width="60" height="60" rx="14" fill="#1e2a38"/>
+  <circle cx="32" cy="32" r="19" fill="url(#ball)"/>
+  <path d="M17.5 21 A 24 24 0 0 1 17.5 43" fill="none" stroke="#ffffff" stroke-width="2.6" stroke-linecap="round"/>
+  <path d="M46.5 21 A 24 24 0 0 0 46.5 43" fill="none" stroke="#ffffff" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/packages/logseq-live-tennis/manifest.json
+++ b/packages/logseq-live-tennis/manifest.json
@@ -1,0 +1,8 @@
+{
+  "title": "Tennis Capture",
+  "description": "Capture tennis into your notes — today's fixtures, recent results, player rankings, and one-shot live-score snapshots from the Live Tennis API.",
+  "author": "Live Tennis API",
+  "repo": "livetennisapi/logseq-live-tennis",
+  "icon": "./logo.svg",
+  "supportsDB": true
+}


### PR DESCRIPTION
Adds [Tennis Capture](https://github.com/livetennisapi/logseq-live-tennis) — slash commands that capture tennis into notes: today's fixtures (`/tennis-today`), recent results (`/tennis-results`), a player's current ranking (`/tennis-player`), and a one-shot live-score snapshot (`/tennis-live`). One-shot inserts into plain blocks — no polling.

- Release [v0.1.0](https://github.com/livetennisapi/logseq-live-tennis/releases/tag/v0.1.0) with the built `logseq-live-tennis.zip` attached via the publish workflow
- Uses only `logseq.Editor` block APIs, so it works on both file and DB graphs (`supportsDB: true`)
- FREE API tier covers three of the four commands; `/tennis-results` needs a paid tier and says so clearly on 403

Disclosure: I maintain the API it uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)