### PR TITLE
Add Awesome Links DB (logseq-awesome-links-db)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -6584,6 +6584,16 @@
       "theme": true,
       "id": "xypora-print-theme",
       "addedAt": 1760749797000
+    },
+    {
+      "title": "Awesome Links DB",
+      "description": "Icons and colors for internal links, inherited from their tag, and favicons for external links. For database graphs.",
+      "author": "MrModest",
+      "repo": "MrModest/logseq-awesome-links-db",
+      "icon": "./icon.png",
+      "effect": true,
+      "supportsDB": true,
+      "supportsDBOnly": true
     }
   ]
 }


### PR DESCRIPTION
# Submit a new Plugin to Marketplace

**Plugin GitHub repo URL:** https://github.com/MrModest/logseq-awesome-links-db

## GitHub releases checklist

- [x] a legal [package.json](https://gist.github.com/xyhp915/bb9f67f5b430ac0da2629d586a3e4d69#explain-packagejson) file.
- [x] a [valid CI workflow](https://github.com/xyhp915/logseq-journals-calendar/blob/main/.github/workflows/publish.yml#L10) build action for Github releases.
- [x] a release which includes a release zip pkg from a successful build.
- [x] a clear README file, ideally with an image or gif showcase.
- [x] a license in the LICENSE file.

## What it does

Icons and colors for links in **database graphs**.

A node with no icon of its own is rendered with the icon and color of its first tag, so a page tagged `#Project` picks up the icon set on `#Project` — in the page title, in inline references, in the left sidebar and in tabs. External links get the favicon of their host, with built-in rules for Google Docs / Sheets / Drive, Jira, Slack and Grafana, and a user-defined rule list for hosts no public favicon service can reach, such as a self-hosted Confluence.

Logseq already resolves a first-tag icon in `get-node-icon`, but the `page?` branch of that `cond` is reached first for anything page-shaped and returns the generic `"file"` icon, which the link renderer then discards. This plugin fills that gap. Icons render through the Tabler webfont the app already loads, so nothing extra is bundled.

## Notes for review

- **`supportsDBOnly: true`.** This is a rewrite of a file-graph plugin for DB graphs; the file-graph code paths are removed rather than kept behind a flag, so it is deliberately not offered to file-graph users.
- **`effect: true`.** The plugin decorates links that Logseq renders in the main document — it reads `:logseq.property/icon` through `logseq.DB.datascriptQuery` and injects an icon element into existing anchors. That is not reachable from a sandboxed iframe. It makes no network requests of its own beyond loading favicon images by URL.
- **Fork attribution.** This is a fork of [yoyurec/logseq-awesome-links](https://github.com/yoyurec/logseq-awesome-links) (MIT, last released 2023). The original copyright notice is kept in `LICENSE` alongside the fork's, the original author is credited in the README and listed under `contributors` in `package.json`. Published under a new plugin id, so it does not collide with the existing marketplace entry.
